### PR TITLE
Audit bug fixes - MinPoolContribution fix & channelUpdateBlock removal

### DIFF
--- a/contracts/EPNSCore/EPNSCoreV1_5.sol
+++ b/contracts/EPNSCore/EPNSCoreV1_5.sol
@@ -170,7 +170,7 @@ contract EPNSCoreV1_5 is
         lendingPoolProviderAddress = _lendingPoolProviderAddress;
 
         FEE_AMOUNT = 10 ether; // PUSH Amount that will be charged as Protocol Pool Fees
-        MIN_POOL_CONTRIBUTION = 1 ether; // Channel's poolContribution should never go below MIN_POOL_CONTRIBUTION
+        MIN_POOL_CONTRIBUTION = 50 ether; // Channel's poolContribution should never go below MIN_POOL_CONTRIBUTION
         ADD_CHANNEL_MIN_FEES = 50 ether; // can never be below MIN_POOL_CONTRIBUTION
 
         ADJUST_FOR_FLOAT = 10**7;
@@ -231,6 +231,14 @@ contract EPNSCoreV1_5 is
             "EPNSCoreV1_5::setFeeAmount: Fee amount must be greater than ZERO"
         );
         FEE_AMOUNT = _newFees;
+    }
+
+    function setMinPoolContribution(uint256 _newAmount) external onlyGovernance {
+        require(
+            _newAmount > 0,
+            "EPNSCoreV1_5::setMinPoolContribution: New Pool Contribution amount must be greater than ZERO"
+        );
+        MIN_POOL_CONTRIBUTION = _newAmount;
     }
 
     function pauseContract() external onlyGovernance {

--- a/contracts/EPNSCore/EPNSCoreV1_Temp.sol
+++ b/contracts/EPNSCore/EPNSCoreV1_Temp.sol
@@ -158,7 +158,7 @@ contract EPNSCoreV1_Temp is Initializable, EPNSCoreStorageV1_5, PausableUpgradea
         lendingPoolProviderAddress = _lendingPoolProviderAddress;
 
         FEE_AMOUNT = 10 ether; // 10 DAI out of total deposited DAIs is charged for Deactivating a Channel
-        MIN_POOL_CONTRIBUTION = 1 ether; // 50 DAI or above to create the channel
+        MIN_POOL_CONTRIBUTION = 50 ether; // 50 DAI or above to create the channel
         ADD_CHANNEL_MIN_FEES = 50 ether; // can never be below MIN_POOL_CONTRIBUTION
 
         ADJUST_FOR_FLOAT = 10**7;

--- a/contracts/EPNSCore/EPNSCoreV1_Temp.sol
+++ b/contracts/EPNSCore/EPNSCoreV1_Temp.sol
@@ -502,7 +502,6 @@ contract EPNSCoreV1_Temp is Initializable, EPNSCoreStorageV1_5, PausableUpgradea
                 CHANNEL_POOL_FUNDS = CHANNEL_POOL_FUNDS.sub(poolFees);
                 uint256 adjustedNewWeight = newPoolContribution.mul(ADJUST_FOR_FLOAT).div(MIN_POOL_CONTRIBUTION);
 
-                channels[_channelAddresses[i]].channelUpdateBlock = block.number;
                 channels[_channelAddresses[i]].channelWeight = adjustedNewWeight;
                 channels[_channelAddresses[i]].poolContribution = newPoolContribution;
                 ITempStorage(_tempStorageAddress).setChannelAdjusted(_channelAddresses[i]);


### PR DESCRIPTION
The PR includes 2 main fixes in **EPNSCoreV1_5** & **EPNSCoreV1_Temp** contracts.

**1. Issue In EPNSCoreV1_5:**
* In v1.5, The MIN_POOL_CONTRIBUTION state variable was supposed to change from 50 PUSH to 1 PUSH.
* However, this change in state variable was made under the _**initialize()**_ function which was already triggered during v1 of the contract and cannot be triggered again.
* This meant that the MIN_POOL_CONTRIBUTION value shall remain 50 PUSH even after upgrade while it should have been 1 PUSH.

**FIX**
- Added **setMinPoolContribution()** function with **onlyGovernance()** modifier in EPNSCoreV1_5 contract, to update MIN_POOL_CONTRIBUTION to its desired value in new version.

**2. Issue with EPNSCoreV1_Temp**
* The channelUpdateBlock being updated in the  **adjustChannelPoolContributions** function was causing issues in the way we fetch channels in the front-end as this function doesn't emit any event.

**FIX**
* Removed channelUpdateBlock line from adjustChannelPoolContributions function.