### PR TITLE
Foundry updates

### DIFF
--- a/testFoundry/PushStaking/BasePushFeePoolStaking.t.sol
+++ b/testFoundry/PushStaking/BasePushFeePoolStaking.t.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.8.20;
 pragma experimental ABIEncoderV2;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
 
 import { BaseTest } from "../BaseTest.t.sol";

--- a/testFoundry/PushStaking/unit_tests/1_migration/migrateEpochDetails/migrateEpochDetails.t.sol
+++ b/testFoundry/PushStaking/unit_tests/1_migration/migrateEpochDetails/migrateEpochDetails.t.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
 
 import { BasePushFeePoolStaking } from "../../../BasePushFeePoolStaking.t.sol";

--- a/testFoundry/PushStaking/unit_tests/1_migration/migrateEpochDetails/migrateEpochDetails.tree
+++ b/testFoundry/PushStaking/unit_tests/1_migration/migrateEpochDetails/migrateEpochDetails.tree
@@ -1,11 +1,11 @@
-.
-└── migrateEpochDetails.t.sol
-    ├── if caller is not Push Admin
-    │   └── REVERT - PushFeePool::onlyPushChannelAdmin: Invalid Caller
-    └── if caller is Push Admin
-        ├── if migration is already completed
-        │   └── REVERT - PushFeePool::isMigrated: Migration Completed
-        └── if migration is not yet completed
-            ├── if array lengths are not equal to _currentEpoch
-            │   └── REVERT - Invalid Length
-            └── Function should update epochRewards and epochToTotalStakedWeight accurately
+migrateEpochDetails.t.sol
+└── when caller is not Push Admin
+    │   └── it REVERT - PushFeePool::onlyPushChannelAdmin: Invalid Caller
+    └── when caller is Push Admin
+        ├── when migration is already completed
+        │   └── it REVERT - PushFeePool::isMigrated: Migration Completed
+        └── when migration is not yet completed
+            ├── when array lengths are not equal to _currentEpoch
+            │   └── it REVERT - Ivalid Length
+            └── it  update epochRewards and epochToTotalStakedWeight accurately
+

--- a/testFoundry/PushStaking/unit_tests/1_migration/migrateUserData/migrateUserData.t.sol
+++ b/testFoundry/PushStaking/unit_tests/1_migration/migrateUserData/migrateUserData.t.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
 
 import { BasePushFeePoolStaking } from "../../../BasePushFeePoolStaking.t.sol";

--- a/testFoundry/PushStaking/unit_tests/1_migration/migrateUserData/migrateUserData.tree
+++ b/testFoundry/PushStaking/unit_tests/1_migration/migrateUserData/migrateUserData.tree
@@ -1,11 +1,12 @@
-.
-└── migrateUserData.t.sol
-    ├── if caller is not Push Admin
-    │   └── REVERT - PushFeePool::onlyPushChannelAdmin: Invalid Caller
-    └── if caller is Push Admin
-        ├── if migration is already completed
-        │   └── REVERT - PushFeePool::isMigrated: Migration Completed
-        └── if migration is not yet completed
-            ├── Check Array lengths: if array lengths are not equal to User's array length
-            │   └── REVERT - Ivalid Length
-            └── Function should update UserFeesInfo accurately
+migrateUserData.t.sol
+└── when caller is not Push Admin
+    │   └── it REVERT - PushFeePool::onlyPushChannelAdmin: Invalid Caller
+    └── when caller is Push Admin
+        ├── when migration is already completed
+        │   └── it REVERT - PushFeePool::isMigrated: Migration Completed
+        └── when migration is not yet completed
+            ├── when array lengths are not equal to User's array length
+            │   └── it REVERT - Ivalid Length
+            └── it should update UserFeesInfo accurately
+
+

--- a/testFoundry/PushStaking/unit_tests/1_migration/migrateUserMappings/migrateUserMappings.t.sol
+++ b/testFoundry/PushStaking/unit_tests/1_migration/migrateUserMappings/migrateUserMappings.t.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
 
 import { BasePushFeePoolStaking } from "../../../BasePushFeePoolStaking.t.sol";

--- a/testFoundry/PushStaking/unit_tests/1_migration/migrateUserMappings/migrateUserMappings.tree
+++ b/testFoundry/PushStaking/unit_tests/1_migration/migrateUserMappings/migrateUserMappings.tree
@@ -1,11 +1,10 @@
-.
-└── migrateUserMappings.t.sol
-    ├── if caller is not Push Admin
-    │   └── REVERT - PushFeePool::onlyPushChannelAdmin: Invalid Caller
-    └── if caller is Push Admin
-        ├── if migration is already completed
-        │   └── REVERT - PushFeePool::isMigrated: Migration Completed
-        └── if migration is not yet completed
-            ├── Check Array lengths: if array lengths are not equal to User's Array length
-            │   └── REVERT - Ivalid Length
-            └── Function should update epochToUserStakedWeight and usersRewardsClaimed mappings accurately
+migrateUserMappings.t.sol
+└── when caller is not Push Admin
+    │   └── it REVERT - PushFeePool::onlyPushChannelAdmin: Invalid Caller
+    └── when caller is Push Admin
+        ├──it  when migration is already completed
+        │   └── it REVERT - PushFeePool::isMigrated: Migration Completed
+        └── when migration is not yet completed
+            ├── when array lengths are not equal to User's Array length
+            │   └── it REVERT - Ivalid Length
+            └── it Function should update epochToUserStakedWeight and usersRewardsClaimed mappings accurately


### PR DESCRIPTION
This PR contains two changes. 

1. The format of tree files has been changed, so that test boilerplate can be generated using those. 
2. Removed the import statement for `forgestd/test.sol`, because the test files already inherit `baseTest`, which already has the `forgestd/test` as a parent contract. 