### PR TITLE
fixed custom error structure

### DIFF
--- a/contracts/PushComm/PushCommV2_5.sol
+++ b/contracts/PushComm/PushCommV2_5.sol
@@ -53,14 +53,14 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2 {
 
     modifier onlyPushChannelAdmin() {
         if (msg.sender != pushChannelAdmin) {
-            revert InvalidCaller();
+            revert Errors.InvalidCaller();
         }
         _;
     }
 
     modifier onlyPushCore() {
         if (msg.sender != EPNSCoreAddress) {
-            revert InvalidCaller();
+            revert Errors.InvalidCaller();
         }
         _;
     }
@@ -103,7 +103,7 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2 {
 
     function transferPushChannelAdminControl(address _newAdmin) external onlyPushChannelAdmin {
         if (_newAdmin == address(0) || _newAdmin == pushChannelAdmin) {
-            revert InvalidArgument("Invalid Argument");
+            revert Errors.InvalidArgument("Invalid Argument");
         }
         pushChannelAdmin = _newAdmin;
     }
@@ -181,7 +181,7 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2 {
         returns (bool)
     {
         if (isMigrationComplete || _channelList.length != _usersList.length) {
-            revert InvalidLogic(
+            revert Errors.InvalidLogic(
                 "_channelList != _usersList OR Migration Complete"
             );
         }
@@ -243,7 +243,7 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2 {
     {
         // EIP-712
         if (subscriber == address(0)) {
-            revert InvalidArgument("Zero address");
+            revert Errors.InvalidArgument("Zero address");
         }
 
         bytes32 domainSeparator =
@@ -255,21 +255,21 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2 {
             // use EIP-1271
             bytes4 result = IERC1271(subscriber).isValidSignature(digest, abi.encodePacked(r, s, v));
             if (result != 0x1626ba7e) {
-                revert InvalidSignature("FROM CONTRACT");
+                revert Errors.InvalidSignature("FROM CONTRACT");
             }
         } else {
             // validate with in contract
             address signatory = ecrecover(digest, v, r, s);
             if (signatory != subscriber) {
-                revert InvalidSignature("FROM EOA");
+                revert Errors.InvalidSignature("FROM EOA");
             }
         }
         if (nonce != nonces[subscriber]++) {
-            revert InvalidSignature("Invalid nonce");
+            revert Errors.InvalidSignature("Invalid nonce");
         }
 
         if (block.timestamp > expiry) {
-            revert InvalidSignature("Signature expired");
+            revert Errors.InvalidSignature("Signature expired");
         }
 
         _subscribe(channel, subscriber);
@@ -373,7 +373,7 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2 {
         bytes32 s
     ) external {
         if (subscriber == address(0)) {
-            revert InvalidArgument("Zero address");
+            revert Errors.InvalidArgument("Zero address");
         }
         // EIP-712
 bytes32 domainSeparator =
@@ -385,21 +385,21 @@ bytes32 domainSeparator =
             // use EIP-1271
             bytes4 result = IERC1271(subscriber).isValidSignature(digest, abi.encodePacked(r, s, v));
             if (result != 0x1626ba7e) {
-                revert InvalidSignature("FROM CONTRACT");
+                revert Errors.InvalidSignature("FROM CONTRACT");
             }
         } else {
             // validate with in contract
             address signatory = ecrecover(digest, v, r, s);
             if (signatory != subscriber) {
-                revert InvalidSignature("FROM EOA");
+                revert Errors.InvalidSignature("FROM EOA");
             }
         }
         if (nonce != nonces[subscriber]++) {
-            revert InvalidSignature("Invalid nonce");
+            revert Errors.InvalidSignature("Invalid nonce");
         }
 
         if (block.timestamp > expiry) {
-            revert InvalidSignature("Signature expired");
+            revert Errors.InvalidSignature("Signature expired");
         }
         _unsubscribe(channel, subscriber);
     }
@@ -684,7 +684,7 @@ bytes32 domainSeparator =
 
     function changeUserChannelSettings(address _channel, uint256 _notifID, string calldata _notifSettings) external {
         if (!isUserSubscribed(_channel, msg.sender)) {
-            revert InvalidSubscriber("Not a subscriber");
+            revert Errors.InvalidSubscriber("Not a subscriber");
         }
         string memory notifSetting = string(abi.encodePacked(Strings.toString(_notifID), "+", _notifSettings));
         userToChannelNotifs[msg.sender][_channel] = notifSetting;
@@ -697,7 +697,7 @@ bytes32 domainSeparator =
 
     function createIncentivizeChatRequest(address requestReceiver, uint256 amount) external {
         if (amount <= 0) {
-            revert InvalidAmount();
+            revert Errors.InvalidAmount();
         }
         address requestSender = msg.sender;
         address coreContract = EPNSCoreAddress;

--- a/contracts/PushComm/PushCommV2_5.sol
+++ b/contracts/PushComm/PushCommV2_5.sol
@@ -17,7 +17,7 @@ import "./PushCommStorageV2.sol";
 import "../interfaces/IERC1271.sol";
 import "../interfaces/IPushCore.sol";
 import { BaseHelper } from "../libraries/BaseHelper.sol";
-import "../libraries/Errors.sol";
+import { Errors } from "../libraries/Errors.sol";
 
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/PushComm/PushCommV2_5.sol
+++ b/contracts/PushComm/PushCommV2_5.sol
@@ -369,12 +369,14 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2 {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external {
+    )
+        external
+    {
         if (subscriber == address(0)) {
             revert Errors.InvalidArgument_WrongAddress(subscriber);
         }
         // EIP-712
-bytes32 domainSeparator =
+        bytes32 domainSeparator =
             keccak256(abi.encode(DOMAIN_TYPEHASH, NAME_HASH, BaseHelper.getChainId(), address(this)));
         bytes32 structHash = keccak256(abi.encode(UNSUBSCRIBE_TYPEHASH, channel, subscriber, nonce, expiry));
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));

--- a/contracts/PushCore/PushCoreV2_5.sol
+++ b/contracts/PushCore/PushCoreV2_5.sol
@@ -28,7 +28,7 @@ contract PushCoreV2_5 is Initializable, PushCoreStorageV1_5, PausableUpgradeable
     /* ***************
         EVENTS
      *************** */
-event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amountDeposited);
+    event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amountDeposited);
     event RewardsClaimed(address indexed user, uint256 rewardAmount);
     event ChannelVerified(address indexed channel, address indexed verifier);
     event ChannelVerificationRevoked(address indexed channel, address indexed revoker);
@@ -121,8 +121,10 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
 
     function onlyChannelOwner(address _channel) private view {
         if (
-            ((channels[_channel].channelState != 1 && msg.sender != _channel) ||
-                (msg.sender != pushChannelAdmin && _channel != address(0x0)))
+            (
+                (channels[_channel].channelState != 1 && msg.sender != _channel)
+                    || (msg.sender != pushChannelAdmin && _channel != address(0x0))
+            )
         ) {
             revert Errors.UnauthorizedCaller(msg.sender);
         }
@@ -258,17 +260,16 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
     )
         external
         whenNotPaused
-    {        if (_amount < ADD_CHANNEL_MIN_FEES) {
+    {
+        if (_amount < ADD_CHANNEL_MIN_FEES) {
             revert Errors.InvalidArg_LessThanExpected(ADD_CHANNEL_MIN_FEES, _amount);
         }
         if (channels[msg.sender].channelState != 0) {
             revert Errors.Core_InvalidChannel();
         }
         if (
-            _channelType != ChannelType.InterestBearingOpen ||
-            _channelType != ChannelType.InterestBearingMutual ||
-            _channelType != ChannelType.TimeBound ||
-            _channelType != ChannelType.TokenGaited
+            _channelType != ChannelType.InterestBearingOpen || _channelType != ChannelType.InterestBearingMutual
+                || _channelType != ChannelType.TimeBound || _channelType != ChannelType.TokenGaited
         ) {
             revert Errors.Core_InvalidChannelType();
         }
@@ -297,7 +298,9 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
         ChannelType _channelType,
         uint256 _amountDeposited,
         uint256 _channelExpiryTime
-    ) private {
+    )
+        private
+    {
         uint256 poolFeeAmount = FEE_AMOUNT;
         uint256 poolFundAmount = _amountDeposited - poolFeeAmount;
         //store funds in pool_funds & pool_fees
@@ -360,10 +363,8 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
             revert Errors.Core_InvalidChannelType();
         }
         if (
-            (msg.sender != _channelAddress &&
-                channelData.expiryTime >= block.timestamp) ||
-            (msg.sender != pushChannelAdmin &&
-                channelData.expiryTime + 14 days >= block.timestamp)
+            (msg.sender != _channelAddress && channelData.expiryTime >= block.timestamp)
+                || (msg.sender != pushChannelAdmin && channelData.expiryTime + 14 days >= block.timestamp)
         ) {
             revert Errors.UnauthorizedCaller(msg.sender);
         }
@@ -475,11 +476,11 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
      */
 
     function reactivateChannel(uint256 _amount) external whenNotPaused {
-        if(_amount < ADD_CHANNEL_MIN_FEES){
+        if (_amount < ADD_CHANNEL_MIN_FEES) {
             revert Errors.InvalidArg_LessThanExpected(ADD_CHANNEL_MIN_FEES, _amount);
         }
 
-        if(channels[msg.sender].channelState != 2){
+        if (channels[msg.sender].channelState != 2) {
             revert Errors.Core_InvalidChannel();
         }
 
@@ -520,10 +521,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
 
     function blockChannel(address _channelAddress) external whenNotPaused {
         onlyPushChannelAdmin();
-        if (
-            ((channels[_channelAddress].channelState == 3) &&
-                (channels[_channelAddress].channelState == 0))
-        ) {
+        if (((channels[_channelAddress].channelState == 3) && (channels[_channelAddress].channelState == 0))) {
             revert Errors.Core_InvalidChannel();
         }
         uint256 minPoolContribution = MIN_POOL_CONTRIBUTION;
@@ -562,11 +560,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
         bool logicComplete = false;
 
         // Check if it's primary verification
-        if (
-            verifiedBy == pushChannelAdmin ||
-            _channel == address(0x0) ||
-            _channel == pushChannelAdmin
-        ) {
+        if (verifiedBy == pushChannelAdmin || _channel == address(0x0) || _channel == pushChannelAdmin) {
             // primary verification, mark and exit
             verificationStatus = 1;
         } else {
@@ -636,10 +630,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
      *
      */
     function unverifyChannel(address _channel) public {
-        if (
-            channels[_channel].verifiedBy != msg.sender ||
-            msg.sender != pushChannelAdmin
-        ) {
+        if (channels[_channel].verifiedBy != msg.sender || msg.sender != pushChannelAdmin) {
             revert Errors.CallerNotAdmin();
         }
 
@@ -687,7 +678,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
      */
 
     function handleChatRequestData(address requestSender, address requestReceiver, uint256 amount) external {
-          if (msg.sender != epnsCommunicator) {
+        if (msg.sender != epnsCommunicator) {
             revert Errors.UnauthorizedCaller(msg.sender);
         }
         uint256 poolFeeAmount = FEE_AMOUNT;

--- a/contracts/PushCore/PushCoreV2_5.sol
+++ b/contracts/PushCore/PushCoreV2_5.sol
@@ -15,7 +15,7 @@ import "./PushCoreStorageV2.sol";
 import "../interfaces/IPUSH.sol";
 import "../interfaces/IUniswapV2Router.sol";
 import "../interfaces/IEPNSCommV1.sol";
-import "../libraries/Errors.sol";
+import { Errors } from "../libraries/Errors.sol";
 
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
@@ -103,19 +103,19 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
     *************** */
     function onlyPushChannelAdmin() private view {
         if (msg.sender != pushChannelAdmin) {
-            revert InvalidCaller();
+            revert Errors.InvalidCaller();
         }
     }
 
     function onlyGovernance() private view {
         if (msg.sender != governance) {
-            revert InvalidCaller();
+            revert Errors.InvalidCaller();
         }
     }
 
     function onlyActivatedChannels(address _channel) private view {
         if (channels[_channel].channelState != 1) {
-            revert InvalidChannel();
+            revert Errors.InvalidChannel();
         }
     }
 
@@ -124,7 +124,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
             ((channels[_channel].channelState != 1 && msg.sender != _channel) ||
                 (msg.sender != pushChannelAdmin && _channel != address(0x0)))
         ) {
-            revert InvalidCaller();
+            revert Errors.InvalidCaller();
         }
     }
 
@@ -146,7 +146,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
     function setFeeAmount(uint256 _newFees) external {
         onlyGovernance();
         if (_newFees <= 0 && _newFees > ADD_CHANNEL_MIN_FEES) {
-            revert InvalidArgument("Invalid Argument");
+            revert Errors.InvalidArgument("Invalid Argument");
         }
         FEE_AMOUNT = _newFees;
     }
@@ -154,7 +154,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
     function setMinPoolContribution(uint256 _newAmount) external {
         onlyGovernance();
         if (_newAmount <= 0) {
-            revert InvalidArgument("invalid Argument");
+            revert Errors.InvalidArgument("invalid Argument");
         }
         MIN_POOL_CONTRIBUTION = _newAmount;
     }
@@ -180,7 +180,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
     function setMinChannelCreationFees(uint256 _newFees) external {
         onlyGovernance();
         if (_newFees < MIN_POOL_CONTRIBUTION) {
-            revert InvalidArgument("Invalid Argument");
+            revert Errors.InvalidArgument("Invalid Argument");
         }
         ADD_CHANNEL_MIN_FEES = _newFees;
     }
@@ -188,7 +188,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
     function transferPushChannelAdminControl(address _newAdmin) external {
         onlyPushChannelAdmin();
         if (_newAdmin == address(0) || _newAdmin == pushChannelAdmin) {
-            revert InvalidArgument("Invalid Argument");
+            revert Errors.InvalidArgument("Invalid Argument");
         }
         pushChannelAdmin = _newAdmin;
     }
@@ -227,7 +227,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
         uint256 requiredFees = ADD_CHANNEL_MIN_FEES * updateCounter;
 
         if (_amount < requiredFees) {
-            revert InvalidAmount();
+            revert Errors.InvalidAmount();
         }
 
         PROTOCOL_POOL_FEES = PROTOCOL_POOL_FEES + _amount;
@@ -259,10 +259,10 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
         external
         whenNotPaused
     {        if (_amount < ADD_CHANNEL_MIN_FEES) {
-            revert InvalidAmount();
+            revert Errors.InvalidAmount();
         }
         if (channels[msg.sender].channelState != 0) {
-            revert InvalidChannel();
+            revert Errors.InvalidChannel();
         }
         if (
             _channelType != ChannelType.InterestBearingOpen ||
@@ -270,7 +270,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
             _channelType != ChannelType.TimeBound ||
             _channelType != ChannelType.TokenGaited
         ) {
-            revert InvalidArgument("Invalid Channel Type");
+            revert Errors.InvalidArgument("Invalid Channel Type");
         }
 
         emit AddChannel(msg.sender, _channelType, _identity);
@@ -319,7 +319,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
 
         if (_channelType == ChannelType.TimeBound) {
             if (_channelExpiryTime <= block.timestamp) {
-                revert InvalidArgument("Invalid channelExpiryTime");
+                revert Errors.InvalidArgument("Invalid channelExpiryTime");
             }
             channels[_channel].expiryTime = _channelExpiryTime;
         }
@@ -357,7 +357,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
         Channel memory channelData = channels[_channelAddress];
 
         if (channelData.channelType != ChannelType.TimeBound) {
-            revert InvalidChannel();
+            revert Errors.InvalidChannel();
         }
         if (
             (msg.sender != _channelAddress &&
@@ -365,7 +365,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
             (msg.sender != pushChannelAdmin &&
                 channelData.expiryTime + 14 days >= block.timestamp)
         ) {
-            revert InvalidArgument("Invalid Caller or Channel Not Expired");
+            revert Errors.InvalidArgument("Invalid Caller or Channel Not Expired");
         }
         uint256 totalRefundableAmount = channelData.poolContribution;
 
@@ -421,7 +421,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
     {
         onlyActivatedChannels(msg.sender);
         if (_amountDeposited < ADD_CHANNEL_MIN_FEES) {
-            revert InvalidAmount();
+            revert Errors.InvalidAmount();
         }
         string memory notifSetting = string(abi.encodePacked(Strings.toString(_notifOptions), "+", _notifSettings));
         channelNotifSettings[msg.sender] = notifSetting;
@@ -479,7 +479,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
             _amount < ADD_CHANNEL_MIN_FEES ||
             channels[msg.sender].channelState != 2
         ) {
-            revert InvalidArgument("Invalid Amount Or Channel Is Active");
+            revert Errors.InvalidArgument("Invalid Amount Or Channel Is Active");
         }
 
         IERC20(PUSH_TOKEN_ADDRESS).safeTransferFrom(msg.sender, address(this), _amount);
@@ -523,7 +523,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
             ((channels[_channelAddress].channelState == 3) &&
                 (channels[_channelAddress].channelState == 0))
         ) {
-            revert InvalidChannel();
+            revert Errors.InvalidChannel();
         }
         uint256 minPoolContribution = MIN_POOL_CONTRIBUTION;
         Channel storage channelData = channels[_channelAddress];
@@ -612,13 +612,13 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
         // Check if caller is verified first
         uint8 callerVerified = getChannelVerfication(msg.sender);
         if (callerVerified <= 0) {
-            revert InvalidCallerParam("Unverified Caller");
+            revert Errors.InvalidCallerParam("Unverified Caller");
         }
 
         // Check if channel is verified
         uint8 channelVerified = getChannelVerfication(_channel);
         if (channelVerified != 0 || msg.sender != pushChannelAdmin) {
-            revert InvalidChannel();
+            revert Errors.InvalidChannel();
         }
 
         // Verify channel
@@ -639,7 +639,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
             channels[_channel].verifiedBy != msg.sender ||
             msg.sender != pushChannelAdmin
         ) {
-            revert InvalidCaller();
+            revert Errors.InvalidCaller();
         }
 
         // Unverify channel
@@ -660,7 +660,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
 
     function sendFunds(address _user, uint256 _amount) external {
         if (msg.sender != feePoolStakingContract) {
-            revert InvalidCaller();
+            revert Errors.InvalidCaller();
         }
         IERC20(PUSH_TOKEN_ADDRESS).transfer(_user, _amount);
     }
@@ -687,7 +687,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
 
     function handleChatRequestData(address requestSender, address requestReceiver, uint256 amount) external {
           if (msg.sender != epnsCommunicator) {
-            revert InvalidCaller();
+            revert Errors.InvalidCaller();
         }
         uint256 poolFeeAmount = FEE_AMOUNT;
         uint256 requestReceiverAmount = amount - poolFeeAmount;
@@ -707,7 +707,7 @@ event UpdateChannel(address indexed channel, bytes identity, uint256 indexed amo
      */
     function claimChatIncentives(uint256 _amount) external {
         if (celebUserFunds[msg.sender] < _amount) {
-            revert InvalidAmount();
+            revert Errors.InvalidAmount();
         }
 
         celebUserFunds[msg.sender] -= _amount;

--- a/contracts/PushCore/PushCoreV2_Temp.sol
+++ b/contracts/PushCore/PushCoreV2_Temp.sol
@@ -15,7 +15,7 @@ import "./PushCoreStorageV2.sol";
 import "../interfaces/IPUSH.sol";
 import "../interfaces/IUniswapV2Router.sol";
 import "../interfaces/IEPNSCommV1.sol";
-import "../libraries/Errors.sol";
+import { Errors } from "../libraries/Errors.sol";
 
 import "@openzeppelin/contracts/utils/Strings.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/PushCore/PushCoreV2_Temp.sol
+++ b/contracts/PushCore/PushCoreV2_Temp.sol
@@ -103,19 +103,19 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
     *************** */
     function onlyPushChannelAdmin() private view {
         if (msg.sender != pushChannelAdmin) {
-            revert InvalidCaller();
+            revert Errors.InvalidCaller();
         }
     }
 
     function onlyGovernance() private view {
         if (msg.sender != governance) {
-            revert InvalidCaller();
+            revert Errors.InvalidCaller();
         }
     }
 
     function onlyActivatedChannels(address _channel) private view {
         if (channels[_channel].channelState != 1) {
-            revert InvalidChannel();
+            revert Errors.InvalidChannel();
         }
     }
 
@@ -124,7 +124,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
             ((channels[_channel].channelState != 1 && msg.sender != _channel) ||
                 (msg.sender != pushChannelAdmin && _channel != address(0x0)))
         ) {
-            revert InvalidCaller();
+            revert Errors.InvalidCaller();
         }
     }
 
@@ -146,7 +146,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
     function setFeeAmount(uint256 _newFees) external {
         onlyGovernance();
         if (_newFees <= 0 && _newFees > ADD_CHANNEL_MIN_FEES) {
-            revert InvalidArgument("Invalid Argument");
+            revert Errors.InvalidArgument("Invalid Argument");
         }
         FEE_AMOUNT = _newFees;
     }
@@ -154,7 +154,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
     function setMinPoolContribution(uint256 _newAmount) external {
         onlyGovernance();
         if (_newAmount <= 0) {
-            revert InvalidArgument("invalid Argument");
+            revert Errors.InvalidArgument("invalid Argument");
         }
         MIN_POOL_CONTRIBUTION = _newAmount;
     }
@@ -180,7 +180,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
     function setMinChannelCreationFees(uint256 _newFees) external {
         onlyGovernance();
         if (_newFees < MIN_POOL_CONTRIBUTION) {
-            revert InvalidArgument("Invalid Argument");
+            revert Errors.InvalidArgument("Invalid Argument");
         }
         ADD_CHANNEL_MIN_FEES = _newFees;
     }
@@ -189,7 +189,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
         onlyPushChannelAdmin();
 
         if (_newAdmin == address(0) || _newAdmin == pushChannelAdmin) {
-            revert InvalidArgument("Invalid Argument");
+            revert Errors.InvalidArgument("Invalid Argument");
         }
         pushChannelAdmin = _newAdmin;
     }
@@ -228,7 +228,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
         uint256 requiredFees = ADD_CHANNEL_MIN_FEES * updateCounter;
 
         if (_amount < requiredFees) {
-            revert InvalidAmount();
+            revert Errors.InvalidAmount();
         }
 
         PROTOCOL_POOL_FEES = PROTOCOL_POOL_FEES + _amount;
@@ -260,10 +260,10 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
         external
         whenNotPaused
     {        if (_amount < ADD_CHANNEL_MIN_FEES) {
-            revert InvalidAmount();
+            revert Errors.InvalidAmount();
         }
         if (channels[msg.sender].channelState != 0) {
-            revert InvalidChannel();
+            revert Errors.InvalidChannel();
         }
         if (
             _channelType != ChannelType.InterestBearingOpen ||
@@ -271,7 +271,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
             _channelType != ChannelType.TimeBound ||
             _channelType != ChannelType.TokenGaited
         ) {
-            revert InvalidArgument("Invalid Channel Type");
+            revert Errors.InvalidArgument("Invalid Channel Type");
         }
 
         emit AddChannel(msg.sender, _channelType, _identity);
@@ -322,7 +322,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
 
         if (_channelType == ChannelType.TimeBound) {
             if (_channelExpiryTime <= block.timestamp) {
-                revert InvalidArgument("Invalid channelExpiryTime");
+                revert Errors.InvalidArgument("Invalid channelExpiryTime");
             }
             channels[_channel].expiryTime = _channelExpiryTime;
         }
@@ -360,7 +360,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
         Channel memory channelData = channels[_channelAddress];
 
         if (channelData.channelType != ChannelType.TimeBound) {
-            revert InvalidChannel();
+            revert Errors.InvalidChannel();
         }
         if (
             (msg.sender != _channelAddress &&
@@ -368,7 +368,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
             (msg.sender != pushChannelAdmin &&
                 channelData.expiryTime + 14 days >= block.timestamp)
         ) {
-            revert InvalidArgument("Invalid Caller or Channel Not Expired");
+            revert Errors.InvalidArgument("Invalid Caller or Channel Not Expired");
         }
         uint256 totalRefundableAmount = channelData.poolContribution;
 
@@ -424,7 +424,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
     {
         onlyActivatedChannels(msg.sender);
          if (_amountDeposited < ADD_CHANNEL_MIN_FEES) {
-            revert InvalidAmount();
+            revert Errors.InvalidAmount();
             }
         string memory notifSetting = string(abi.encodePacked(Strings.toString(_notifOptions), "+", _notifSettings));
         channelNotifSettings[msg.sender] = notifSetting;
@@ -482,7 +482,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
             _amount < ADD_CHANNEL_MIN_FEES ||
             channels[msg.sender].channelState != 2
         ) {
-            revert InvalidArgument("Invalid Amount Or Active Channel");
+            revert Errors.InvalidArgument("Invalid Amount Or Active Channel");
         }
 
         IERC20(PUSH_TOKEN_ADDRESS).safeTransferFrom(msg.sender, address(this), _amount);
@@ -526,7 +526,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
             ((channels[_channelAddress].channelState == 3) &&
                 (channels[_channelAddress].channelState == 0))
         ) {
-            revert InvalidChannel();
+            revert Errors.InvalidChannel();
         }
         uint256 minPoolContribution = MIN_POOL_CONTRIBUTION;
         Channel storage channelData = channels[_channelAddress];
@@ -615,13 +615,13 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
         // Check if caller is verified first
         uint8 callerVerified = getChannelVerfication(msg.sender);
         if (callerVerified <= 0) {
-            revert InvalidCallerParam("Unverified Caller");
+            revert Errors.InvalidCallerParam("Unverified Caller");
         }
 
         // Check if channel is verified
         uint8 channelVerified = getChannelVerfication(_channel);
         if (channelVerified != 0 || msg.sender != pushChannelAdmin) {
-            revert InvalidChannel();
+            revert Errors.InvalidChannel();
         }
 
         // Verify channel
@@ -642,7 +642,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
             channels[_channel].verifiedBy != msg.sender ||
             msg.sender != pushChannelAdmin
         ) {
-            revert InvalidCaller();
+            revert Errors.InvalidCaller();
         }
 
         // Unverify channel
@@ -686,7 +686,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
      */
     function lastEpochRelative(uint256 _from, uint256 _to) public view returns (uint256) {
         if (_to < _from) {
-            revert InvalidArgument("To < from");
+            revert Errors.InvalidArgument("To < from");
         }
 
         return uint256((_to - _from) / epochDuration + 1);
@@ -711,7 +711,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
      */
     function initializeStake() external {
         if (genesisEpoch != 0) {
-            revert InvalidLogic("Already Initialized");
+            revert Errors.InvalidLogic("Already Initialized");
         }
 
         genesisEpoch = block.number;
@@ -759,10 +759,10 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
             block.number <=
             userFeesInfo[msg.sender].lastStakedBlock + epochDuration
         ) {
-            revert InvalidEpoch("incomplete epoch");
+            revert Errors.InvalidEpoch("incomplete epoch");
         }
         if (userFeesInfo[msg.sender].stakedAmount <= 0) {
-            revert InvalidCallerParam("not a staker");
+            revert Errors.InvalidCallerParam("not a staker");
         }
 
         harvestAll();
@@ -834,10 +834,10 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
         uint256 nextFromEpoch = lastEpochRelative(genesisEpoch, userFeesInfo[_user].lastClaimedBlock);
 
         if (currentEpoch <= _tillEpoch) {
-            revert InvalidEpoch("currentEpoch <= _tillEpoch");
+            revert Errors.InvalidEpoch("currentEpoch <= _tillEpoch");
         }
         if (_tillEpoch < nextFromEpoch) {
-            revert InvalidEpoch("_tillEpoch < nextFromEpoch");
+            revert Errors.InvalidEpoch("_tillEpoch < nextFromEpoch");
         }
         for (uint256 i = nextFromEpoch; i <= _tillEpoch; i++) {
             uint256 claimableReward = calculateEpochRewards(_user, i);
@@ -967,7 +967,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
      */
     function handleChatRequestData(address requestSender, address requestReceiver, uint256 amount) external {
         if (msg.sender != epnsCommunicator) {
-            revert InvalidCaller();
+            revert Errors.InvalidCaller();
         }
 
         uint256 poolFeeAmount = FEE_AMOUNT;
@@ -988,7 +988,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
      */
     function claimChatIncentives(uint256 _amount) external {
         if (celebUserFunds[msg.sender] < _amount) {
-            revert InvalidAmount();
+            revert Errors.InvalidAmount();
         }
 
         celebUserFunds[msg.sender] -= _amount;

--- a/contracts/PushCore/PushCoreV2_Temp.sol
+++ b/contracts/PushCore/PushCoreV2_Temp.sol
@@ -121,8 +121,10 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
 
     function onlyChannelOwner(address _channel) private view {
         if (
-            ((channels[_channel].channelState != 1 && msg.sender != _channel) ||
-                (msg.sender != pushChannelAdmin && _channel != address(0x0)))
+            (
+                (channels[_channel].channelState != 1 && msg.sender != _channel)
+                    || (msg.sender != pushChannelAdmin && _channel != address(0x0))
+            )
         ) {
             revert Errors.UnauthorizedCaller(msg.sender);
         }
@@ -258,17 +260,16 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
     )
         external
         whenNotPaused
-    {        if (_amount < ADD_CHANNEL_MIN_FEES) {
+    {
+        if (_amount < ADD_CHANNEL_MIN_FEES) {
             revert Errors.InvalidArg_LessThanExpected(ADD_CHANNEL_MIN_FEES, _amount);
         }
         if (channels[msg.sender].channelState != 0) {
             revert Errors.Core_InvalidChannel();
         }
         if (
-            _channelType != ChannelType.InterestBearingOpen ||
-            _channelType != ChannelType.InterestBearingMutual ||
-            _channelType != ChannelType.TimeBound ||
-            _channelType != ChannelType.TokenGaited
+            _channelType != ChannelType.InterestBearingOpen || _channelType != ChannelType.InterestBearingMutual
+                || _channelType != ChannelType.TimeBound || _channelType != ChannelType.TokenGaited
         ) {
             revert Errors.Core_InvalidChannelType();
         }
@@ -362,10 +363,8 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
             revert Errors.Core_InvalidChannelType();
         }
         if (
-            (msg.sender != _channelAddress &&
-                channelData.expiryTime >= block.timestamp) ||
-            (msg.sender != pushChannelAdmin &&
-                channelData.expiryTime + 14 days >= block.timestamp)
+            (msg.sender != _channelAddress && channelData.expiryTime >= block.timestamp)
+                || (msg.sender != pushChannelAdmin && channelData.expiryTime + 14 days >= block.timestamp)
         ) {
             revert Errors.UnauthorizedCaller(msg.sender);
         }
@@ -422,9 +421,9 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
         external
     {
         onlyActivatedChannels(msg.sender);
-         if (_amountDeposited < ADD_CHANNEL_MIN_FEES) {
+        if (_amountDeposited < ADD_CHANNEL_MIN_FEES) {
             revert Errors.InvalidArg_LessThanExpected(ADD_CHANNEL_MIN_FEES, _amountDeposited);
-            }
+        }
         string memory notifSetting = string(abi.encodePacked(Strings.toString(_notifOptions), "+", _notifSettings));
         channelNotifSettings[msg.sender] = notifSetting;
 
@@ -477,11 +476,11 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
      */
 
     function reactivateChannel(uint256 _amount) external whenNotPaused {
-        if(_amount < ADD_CHANNEL_MIN_FEES){
+        if (_amount < ADD_CHANNEL_MIN_FEES) {
             revert Errors.InvalidArg_LessThanExpected(ADD_CHANNEL_MIN_FEES, _amount);
         }
 
-        if(channels[msg.sender].channelState != 2){
+        if (channels[msg.sender].channelState != 2) {
             revert Errors.Core_InvalidChannel();
         }
 
@@ -522,10 +521,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
 
     function blockChannel(address _channelAddress) external whenNotPaused {
         onlyPushChannelAdmin();
-        if (
-            ((channels[_channelAddress].channelState == 3) &&
-                (channels[_channelAddress].channelState == 0))
-        ) {
+        if (((channels[_channelAddress].channelState == 3) && (channels[_channelAddress].channelState == 0))) {
             revert Errors.Core_InvalidChannel();
         }
         uint256 minPoolContribution = MIN_POOL_CONTRIBUTION;
@@ -564,11 +560,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
         bool logicComplete = false;
 
         // Check if it's primary verification
-        if (
-            verifiedBy == pushChannelAdmin ||
-            _channel == address(0x0) ||
-            _channel == pushChannelAdmin
-        ) {
+        if (verifiedBy == pushChannelAdmin || _channel == address(0x0) || _channel == pushChannelAdmin) {
             // primary verification, mark and exit
             verificationStatus = 1;
         } else {
@@ -638,10 +630,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
      *
      */
     function unverifyChannel(address _channel) public {
-        if (
-            channels[_channel].verifiedBy != msg.sender ||
-            msg.sender != pushChannelAdmin
-        ) {
+        if (channels[_channel].verifiedBy != msg.sender || msg.sender != pushChannelAdmin) {
             revert Errors.CallerNotAdmin();
         }
 
@@ -711,7 +700,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
      */
     function initializeStake() external {
         if (genesisEpoch != 0) {
-            revert ("Already Initialized");
+            revert("Already Initialized");
         }
 
         genesisEpoch = block.number;
@@ -755,10 +744,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
      *
      */
     function unstake() external whenNotPaused {
-        if (
-            block.number <=
-            userFeesInfo[msg.sender].lastStakedBlock + epochDuration
-        ) {
+        if (block.number <= userFeesInfo[msg.sender].lastStakedBlock + epochDuration) {
             revert Errors.PushStaking_InvalidEpoch_LessThanExpected();
         }
         if (userFeesInfo[msg.sender].stakedAmount <= 0) {
@@ -833,7 +819,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
         uint256 currentEpoch = lastEpochRelative(genesisEpoch, block.number);
         uint256 nextFromEpoch = lastEpochRelative(genesisEpoch, userFeesInfo[_user].lastClaimedBlock);
 
-           if (currentEpoch <= _tillEpoch) {
+        if (currentEpoch <= _tillEpoch) {
             revert Errors.PushStaking_InvalidEpoch_LessThanExpected();
         }
         if (_tillEpoch < nextFromEpoch) {

--- a/contracts/PushStaking/PushFeePoolStaking.sol
+++ b/contracts/PushStaking/PushFeePoolStaking.sol
@@ -43,13 +43,13 @@ contract PushFeePoolStaking is Initializable, PushFeePoolStorage {
 
     modifier onlyPushChannelAdmin() {
         if (msg.sender != pushChannelAdmin) {
-            revert InvalidCaller();
+            revert Errors.InvalidCaller();
         }        _;
     }
 
     modifier isMigrated() {
         if(migrated){
-            revert InvalidLogic("Migration Completed");
+            revert Errors.InvalidLogic("Migration Completed");
         }
         _;
     }
@@ -72,7 +72,7 @@ contract PushFeePoolStaking is Initializable, PushFeePoolStorage {
             _currentEpoch != _epochRewards.length ||
             _currentEpoch != _epochToTotalStakedWeight.length
         ) {
-            revert InvalidArgument("Invalid Length");
+            revert Errors.InvalidArgument("Invalid Length");
         }
 
         for (uint256 i; i < _currentEpoch; ++i) {
@@ -100,7 +100,7 @@ contract PushFeePoolStaking is Initializable, PushFeePoolStorage {
             _user.length != _lastStakedBlock.length ||
             _user.length != _lastClaimedBlock.length
         ) {
-            revert InvalidArgument("Invalid Length");
+            revert Errors.InvalidArgument("Invalid Length");
         }
         for (uint256 i = start; i < end; ++i) {
             userFeesInfo[_user[i]].stakedAmount = _stakedAmount[i];
@@ -126,7 +126,7 @@ contract PushFeePoolStaking is Initializable, PushFeePoolStorage {
             _user.length != _epochToUserStakedWeight.length ||
             _user.length != _userRewardsClaimed.length
         ) {
-            revert InvalidArgument("Invalid Length");
+            revert Errors.InvalidArgument("Invalid Length");
         }
 
         for (uint256 i = startIndex; i < endIndex; ++i) {
@@ -165,7 +165,7 @@ contract PushFeePoolStaking is Initializable, PushFeePoolStorage {
      */
     function lastEpochRelative(uint256 _from, uint256 _to) public pure returns (uint256) {
         if (_to < _from) {
-            revert InvalidArgument("To < from");
+            revert Errors.InvalidArgument("To < from");
         }
         return uint256((_to - _from) / epochDuration + 1);
     }
@@ -221,10 +221,10 @@ contract PushFeePoolStaking is Initializable, PushFeePoolStorage {
             block.number <=
             userFeesInfo[msg.sender].lastStakedBlock + epochDuration
         ) {
-            revert InvalidEpoch("incomplete epoch");
+            revert Errors.InvalidEpoch("incomplete epoch");
         }
         if (userFeesInfo[msg.sender].stakedAmount <= 0) {
-            revert InvalidCallerParam("not a staker");
+            revert Errors.InvalidCallerParam("not a staker");
         }
         harvestAll();
         uint256 stakedAmount = userFeesInfo[msg.sender].stakedAmount;
@@ -275,7 +275,7 @@ contract PushFeePoolStaking is Initializable, PushFeePoolStorage {
      */
     function daoHarvestPaginated(uint256 _tillEpoch) external {
         if (msg.sender != governance) {
-            revert InvalidCaller();
+            revert Errors.InvalidCaller();
         }
         uint256 rewards = harvest(core, _tillEpoch);
         IPushCore(core).sendFunds(msg.sender, rewards);
@@ -297,10 +297,10 @@ contract PushFeePoolStaking is Initializable, PushFeePoolStorage {
         uint256 nextFromEpoch = lastEpochRelative(genesisEpoch, userFeesInfo[_user].lastClaimedBlock);
 
         if (currentEpoch <= _tillEpoch) {
-            revert InvalidEpoch("currentEpoch <= _tillEpoch");
+            revert Errors.InvalidEpoch("currentEpoch <= _tillEpoch");
         }
         if (_tillEpoch < nextFromEpoch) {
-            revert InvalidEpoch("_tillEpoch < nextFromEpoch");
+            revert Errors.InvalidEpoch("_tillEpoch < nextFromEpoch");
         }
         for (uint256 i = nextFromEpoch; i <= _tillEpoch; i++) {
             uint256 claimableReward = calculateEpochRewards(_user, i);

--- a/contracts/PushStaking/PushFeePoolStaking.sol
+++ b/contracts/PushStaking/PushFeePoolStaking.sol
@@ -44,11 +44,12 @@ contract PushFeePoolStaking is Initializable, PushFeePoolStorage {
     modifier onlyPushChannelAdmin() {
         if (msg.sender != pushChannelAdmin) {
             revert Errors.CallerNotAdmin();
-        }        _;
+        }
+        _;
     }
 
     modifier isMigrated() {
-        if(migrated){
+        if (migrated) {
             revert Errors.PushStaking_MigrationCompleted();
         }
         _;
@@ -68,10 +69,7 @@ contract PushFeePoolStaking is Initializable, PushFeePoolStorage {
         onlyPushChannelAdmin
         isMigrated
     {
-        if (
-            _currentEpoch != _epochRewards.length ||
-            _currentEpoch != _epochToTotalStakedWeight.length
-        ) {
+        if (_currentEpoch != _epochRewards.length || _currentEpoch != _epochToTotalStakedWeight.length) {
             revert Errors.InvalidArg_ArrayLengthMismatch();
         }
 
@@ -95,10 +93,8 @@ contract PushFeePoolStaking is Initializable, PushFeePoolStorage {
         isMigrated
     {
         if (
-            _user.length != _stakedAmount.length ||
-            _user.length != _stakedWeight.length ||
-            _user.length != _lastStakedBlock.length ||
-            _user.length != _lastClaimedBlock.length
+            _user.length != _stakedAmount.length || _user.length != _stakedWeight.length
+                || _user.length != _lastStakedBlock.length || _user.length != _lastClaimedBlock.length
         ) {
             revert Errors.InvalidArg_ArrayLengthMismatch();
         }
@@ -122,10 +118,7 @@ contract PushFeePoolStaking is Initializable, PushFeePoolStorage {
         onlyPushChannelAdmin
         isMigrated
     {
-        if (
-            _user.length != _epochToUserStakedWeight.length ||
-            _user.length != _userRewardsClaimed.length
-        ) {
+        if (_user.length != _epochToUserStakedWeight.length || _user.length != _userRewardsClaimed.length) {
             revert Errors.InvalidArg_ArrayLengthMismatch();
         }
 
@@ -217,10 +210,7 @@ contract PushFeePoolStaking is Initializable, PushFeePoolStorage {
      *
      */
     function unstake() external {
-        if (
-            block.number <=
-            userFeesInfo[msg.sender].lastStakedBlock + epochDuration
-        ) {
+        if (block.number <= userFeesInfo[msg.sender].lastStakedBlock + epochDuration) {
             revert Errors.PushStaking_InvalidEpoch_LessThanExpected();
         }
         if (userFeesInfo[msg.sender].stakedAmount <= 0) {

--- a/contracts/PushStaking/PushFeePoolStaking.sol
+++ b/contracts/PushStaking/PushFeePoolStaking.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.20;
 import "./PushFeePoolStorage.sol";
 import "../interfaces/IPUSH.sol";
 import "../interfaces/IPushCore.sol";
-import "../libraries/Errors.sol";
+import { Errors } from "../libraries/Errors.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -8,16 +8,62 @@ library Errors {
     /* ***************
         Global Errors
     *************** */
-    error InvalidCaller();
+    
+    /// @notice Reverts when `msg.sender` is not the admin of the contract.
+    error CallerNotAdmin();
+    /// @notice Reverts when `msg.sender` is not the admin of the contract.
+    error UnauthorizedCaller(address caller);
+    /// @notice Reverts when address argument is zero address or invalid for the function.
+    error InvalidArgument_WrongAddress(address user);
+    /// @notice Reverts when arrays passed as argument have a mismatch of their length.
+    error InvalidArg_ArrayLengthMismatch();
+    /// @notice Reverts when uint256 argument passed is more than expected value.
+    error InvalidArg_MoreThanExpected(uint256 max_threshold, uint256 actual_value);
+    /// @notice Reverts when uint256 argument passed is less than expected value.
+    error InvalidArg_LessThanExpected(uint256 min_threshold, uint256 actual_value);
 
-    error InvalidCallerParam(string err);
-    error InvalidChannel();
-    error InvalidArgument(string err);
-    error InvalidAmount();
-    error InvalidLogic(string err);
-    error InvalidEpoch(string err);
+    /* ***************
+        CORE Errors
+    *************** */
+    /// @notice Core Contract Error: Reverts when the Channel doesn't fit the required function calling criteria.
+    error Core_InvalidChannel();
+    /// @notice Core Contract Error: Reverts when the Channel Type doesn't fit the required function calling criteria.
+    error Core_InvalidChannelType();
+    /// @notice Core Contract Error: Reverts whenever the expiry time is not in the future.
+    error Core_InvalidExpiryTime();
 
-    error InvalidSignature(string err);
-    error InvalidSubscriber(string err);
+    /* ***************
+        COMM Errors
+    *************** */
+    /// @notice Comm Contract Error: Reverts whenever the nonce is invalid.
+    error Comm_InvalidNonce();
+    /// @notice Comm Contract Error: Reverts whenever the caller is an invalid subscriber.
+    error Comm_InvalidSubscriber();
+    /// @notice Comm Contract Error: Reverts whenever the current time has exceeded the expected end time of a particular function logic.
+    error Comm_TimeExpired(uint256 endTime, uint256 currentTime);
+    /// @notice Comm Contract Error: Reverts whenever the signature is invalid from EIP-712 perspective.
+    error Comm_InvalidSignature_FromEOA();
+     /// @notice Comm Contract Error: Reverts whenever the signature is invalid from EIP-1271 perspective.
+    error Comm_InvalidSignature_FromContract();
+    
+
+    /* ***************
+        Push STAKING Errors
+    *************** */
+    /// @notice PushStaking Contract Error: Reverts only when migration-related functions are called even though migration is completed.
+    error PushStaking_MigrationCompleted();
+    /// @notice PushStaking Contract Error: Reverts only when the Epoch is more than actually required for a partcular staking-related action.
+    error PushStaking_InvalidEpoch_MoreThanExpected();
+    /// @notice PushStaking Contract Error: Reverts only when the Epoch is less than actually required for a partcular staking-related action.
+    error PushStaking_InvalidEpoch_LessThanExpected();
+
+    
+
+
+
+
+
+
+
 
 }

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -4,11 +4,10 @@
 /// @title Errors
 /// @notice Library that includes all custom errors that any contract might use to revert with.
 library Errors {
-
     /* ***************
         Global Errors
     *************** */
-    
+
     /// @notice Reverts when `msg.sender` is not the admin of the contract.
     error CallerNotAdmin();
     /// @notice Reverts when `msg.sender` is not the admin of the contract.
@@ -39,31 +38,24 @@ library Errors {
     error Comm_InvalidNonce();
     /// @notice Comm Contract Error: Reverts whenever the caller is an invalid subscriber.
     error Comm_InvalidSubscriber();
-    /// @notice Comm Contract Error: Reverts whenever the current time has exceeded the expected end time of a particular function logic.
+    /// @notice Comm Contract Error: Reverts whenever the current time has exceeded the expected end time of a
+    /// particular function logic.
     error Comm_TimeExpired(uint256 endTime, uint256 currentTime);
     /// @notice Comm Contract Error: Reverts whenever the signature is invalid from EIP-712 perspective.
     error Comm_InvalidSignature_FromEOA();
-     /// @notice Comm Contract Error: Reverts whenever the signature is invalid from EIP-1271 perspective.
+    /// @notice Comm Contract Error: Reverts whenever the signature is invalid from EIP-1271 perspective.
     error Comm_InvalidSignature_FromContract();
-    
 
     /* ***************
         Push STAKING Errors
     *************** */
-    /// @notice PushStaking Contract Error: Reverts only when migration-related functions are called even though migration is completed.
+    /// @notice PushStaking Contract Error: Reverts only when migration-related functions are called even though
+    /// migration is completed.
     error PushStaking_MigrationCompleted();
-    /// @notice PushStaking Contract Error: Reverts only when the Epoch is more than actually required for a partcular staking-related action.
+    /// @notice PushStaking Contract Error: Reverts only when the Epoch is more than actually required for a partcular
+    /// staking-related action.
     error PushStaking_InvalidEpoch_MoreThanExpected();
-    /// @notice PushStaking Contract Error: Reverts only when the Epoch is less than actually required for a partcular staking-related action.
+    /// @notice PushStaking Contract Error: Reverts only when the Epoch is less than actually required for a partcular
+    /// staking-related action.
     error PushStaking_InvalidEpoch_LessThanExpected();
-
-    
-
-
-
-
-
-
-
-
 }

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -1,13 +1,23 @@
 // // SPDX-License-Identifier: SEE LICENSE IN LICENSE
 // pragma solidity ^0.8.20;
 
-error InvalidCallerParam(string err);
-error InvalidCaller();
-error InvalidChannel();
-error InvalidArgument(string err);
-error InvalidAmount();
-error InvalidLogic(string err);
-error InvalidEpoch(string err);
+/// @title Errors
+/// @notice Library that includes all custom errors that any contract might use to revert with.
+library Errors {
 
-error InvalidSignature(string err);
-error InvalidSubscriber(string err);
+    /* ***************
+        Global Errors
+    *************** */
+    error InvalidCaller();
+
+    error InvalidCallerParam(string err);
+    error InvalidChannel();
+    error InvalidArgument(string err);
+    error InvalidAmount();
+    error InvalidLogic(string err);
+    error InvalidEpoch(string err);
+
+    error InvalidSignature(string err);
+    error InvalidSubscriber(string err);
+
+}

--- a/testFoundry/PushStaking/unit_tests/1_migration/migrateEpochDetails/migrateEpochDetails.t.sol
+++ b/testFoundry/PushStaking/unit_tests/1_migration/migrateEpochDetails/migrateEpochDetails.t.sol
@@ -51,7 +51,11 @@ contract MigrateEpochDetails_Test is BasePushFeePoolStaking {
         feePoolStaking.migrateEpochDetails(_currentEpoch, _epochRewardss, _epochToTotalStakedWeights);
     }
 
-    function test_Revertwhen_UnequalArrayLengthBeforeMigrationCompleted() public whenCallerIsAdmin whenMigrationComplete {
+    function test_Revertwhen_UnequalArrayLengthBeforeMigrationCompleted()
+        public
+        whenCallerIsAdmin
+        whenMigrationComplete
+    {
         uint256 _testEpoch = _currentEpoch - 1;
         vm.expectRevert(bytes("Invalid Length"));
         feePoolStaking.migrateEpochDetails(_testEpoch, _epochRewardss, _epochToTotalStakedWeights);

--- a/testFoundry/PushStaking/unit_tests/1_migration/migrateUserData/migrateUserData.t.sol
+++ b/testFoundry/PushStaking/unit_tests/1_migration/migrateUserData/migrateUserData.t.sol
@@ -6,7 +6,6 @@ import "forge-std/console.sol";
 import { BasePushFeePoolStaking } from "../../../BasePushFeePoolStaking.t.sol";
 
 contract MigrateUserData_Test is BasePushFeePoolStaking {
-
     uint256 start = 0;
     uint256 end = 3;
     address[] _user;
@@ -55,50 +54,66 @@ contract MigrateUserData_Test is BasePushFeePoolStaking {
         vm.expectRevert(bytes("PushFeePoolStaking::onlyPushChannelAdmin: Invalid Caller"));
 
         changePrank(actor.bob_channel_owner);
-        feePoolStaking.migrateUserData(start, end, _user, _stakedAmount, _stakedWeight, _lastStakedBlock, _lastClaimedBlock);
+        feePoolStaking.migrateUserData(
+            start, end, _user, _stakedAmount, _stakedWeight, _lastStakedBlock, _lastClaimedBlock
+        );
     }
 
     function test_Revertwhen_MigratePostMigrationCompleted() public whenCallerIsAdmin whenMigrationComplete {
         feePoolStaking.setMigrationComplete();
         vm.expectRevert(bytes("PushFeePoolStaking::isMigrated: Migration Completed"));
-        feePoolStaking.migrateUserData(start, end, _user, _stakedAmount, _stakedWeight, _lastStakedBlock, _lastClaimedBlock);
+        feePoolStaking.migrateUserData(
+            start, end, _user, _stakedAmount, _stakedWeight, _lastStakedBlock, _lastClaimedBlock
+        );
     }
 
-    function test_Revertwhen_UnequalArrayLengthBeforeMigrationCompleted() public whenCallerIsAdmin whenMigrationComplete {
-        address[] memory  _testUserLength = new address[](2);
+    function test_Revertwhen_UnequalArrayLengthBeforeMigrationCompleted()
+        public
+        whenCallerIsAdmin
+        whenMigrationComplete
+    {
+        address[] memory _testUserLength = new address[](2);
         _testUserLength[0] = address(actor.dan_push_holder);
         _testUserLength[1] = address(actor.tim_push_holder);
 
         vm.expectRevert(bytes("Invalid Length"));
-        feePoolStaking.migrateUserData(start, end, _testUserLength, _stakedAmount, _stakedWeight, _lastStakedBlock, _lastClaimedBlock);
+        feePoolStaking.migrateUserData(
+            start, end, _testUserLength, _stakedAmount, _stakedWeight, _lastStakedBlock, _lastClaimedBlock
+        );
     }
 
-    function testRevertwhen_EndMoreThanLength() public whenCallerIsAdmin whenMigrationNotComplete() {
+    function testRevertwhen_EndMoreThanLength() public whenCallerIsAdmin whenMigrationNotComplete {
         vm.expectRevert();
         uint256 _tempEndIndex = 5;
-        feePoolStaking.migrateUserData(start, _tempEndIndex, _user, _stakedAmount, _stakedWeight, _lastStakedBlock, _lastClaimedBlock);
+        feePoolStaking.migrateUserData(
+            start, _tempEndIndex, _user, _stakedAmount, _stakedWeight, _lastStakedBlock, _lastClaimedBlock
+        );
     }
 
     function test_MigrateBeforeMigrationCompleted() public whenCallerIsAdmin whenMigrationNotComplete {
-        feePoolStaking.migrateUserData(start, end, _user, _stakedAmount, _stakedWeight, _lastStakedBlock, _lastClaimedBlock);
+        feePoolStaking.migrateUserData(
+            start, end, _user, _stakedAmount, _stakedWeight, _lastStakedBlock, _lastClaimedBlock
+        );
 
         // Verifying userData
-        for (uint256 i=start; i<end; ++i) {
+        for (uint256 i = start; i < end; ++i) {
             address _userAddress = _user[i];
             uint256 expectedUserStakedAmount = _stakedAmount[i];
             uint256 expectedUserStakedWeight = _stakedWeight[i];
             uint256 expectedUserLastStakedBlock = _lastStakedBlock[i];
             uint256 expectedUserLastClaimedBlock = _lastClaimedBlock[i];
 
-            (uint256 actualUserStakedAmount, 
-            uint256 actualUserStakedWeight, 
-            uint256 actualUserLastStakedBlock,
-            uint256 actualUserLastClaimedBlock) = feePoolStaking.userFeesInfo(_userAddress);
+            (
+                uint256 actualUserStakedAmount,
+                uint256 actualUserStakedWeight,
+                uint256 actualUserLastStakedBlock,
+                uint256 actualUserLastClaimedBlock
+            ) = feePoolStaking.userFeesInfo(_userAddress);
 
             assertEq(expectedUserStakedAmount, actualUserStakedAmount);
             assertEq(expectedUserStakedWeight, actualUserStakedWeight);
             assertEq(expectedUserLastStakedBlock, actualUserLastStakedBlock);
-            assertEq(expectedUserLastClaimedBlock, actualUserLastClaimedBlock);   
+            assertEq(expectedUserLastClaimedBlock, actualUserLastClaimedBlock);
         }
     }
 }

--- a/testFoundry/PushStaking/unit_tests/1_migration/migrateUserMappings/migrateUserMappings.t.sol
+++ b/testFoundry/PushStaking/unit_tests/1_migration/migrateUserMappings/migrateUserMappings.t.sol
@@ -6,7 +6,6 @@ import "forge-std/console.sol";
 import { BasePushFeePoolStaking } from "../../../BasePushFeePoolStaking.t.sol";
 
 contract MigrateUserMappings_Test is BasePushFeePoolStaking {
-
     uint256 _epoch = 2;
     uint256 startIndex = 0;
     uint256 endIndex = 3;
@@ -48,32 +47,46 @@ contract MigrateUserMappings_Test is BasePushFeePoolStaking {
         vm.expectRevert(bytes("PushFeePoolStaking::onlyPushChannelAdmin: Invalid Caller"));
 
         changePrank(actor.bob_channel_owner);
-        feePoolStaking.migrateUserMappings(_epoch, startIndex, endIndex, _user, _epochToUserStakedWeight, _userRewardsClaimed);
+        feePoolStaking.migrateUserMappings(
+            _epoch, startIndex, endIndex, _user, _epochToUserStakedWeight, _userRewardsClaimed
+        );
     }
 
     function test_Revertwhen_MigratePostMigrationCompleted() public whenCallerIsAdmin whenMigrationComplete {
         feePoolStaking.setMigrationComplete();
         vm.expectRevert(bytes("PushFeePoolStaking::isMigrated: Migration Completed"));
-        feePoolStaking.migrateUserMappings(_epoch, startIndex, endIndex, _user, _epochToUserStakedWeight, _userRewardsClaimed);
+        feePoolStaking.migrateUserMappings(
+            _epoch, startIndex, endIndex, _user, _epochToUserStakedWeight, _userRewardsClaimed
+        );
     }
 
-    function test_Revertwhen_UnequalArrayLengthBeforeMigrationCompleted() public whenCallerIsAdmin whenMigrationComplete {
-        address[] memory  _testUserLength = new address[](2);
+    function test_Revertwhen_UnequalArrayLengthBeforeMigrationCompleted()
+        public
+        whenCallerIsAdmin
+        whenMigrationComplete
+    {
+        address[] memory _testUserLength = new address[](2);
         _testUserLength[0] = address(actor.dan_push_holder);
         _testUserLength[1] = address(actor.tim_push_holder);
 
         vm.expectRevert(bytes("Invalid Length"));
-        feePoolStaking.migrateUserMappings(_epoch, startIndex, endIndex, _testUserLength, _epochToUserStakedWeight, _userRewardsClaimed);
+        feePoolStaking.migrateUserMappings(
+            _epoch, startIndex, endIndex, _testUserLength, _epochToUserStakedWeight, _userRewardsClaimed
+        );
     }
 
-    function testRevertwhen_EndMoreThanLength() public whenCallerIsAdmin whenMigrationNotComplete() {
+    function testRevertwhen_EndMoreThanLength() public whenCallerIsAdmin whenMigrationNotComplete {
         vm.expectRevert();
         uint256 _tempEndIndex = 5;
-        feePoolStaking.migrateUserMappings(_epoch, startIndex, _tempEndIndex, _user, _epochToUserStakedWeight, _userRewardsClaimed);
+        feePoolStaking.migrateUserMappings(
+            _epoch, startIndex, _tempEndIndex, _user, _epochToUserStakedWeight, _userRewardsClaimed
+        );
     }
 
     function test_MigrateBeforeMigrationCompleted() public whenCallerIsAdmin whenMigrationNotComplete {
-        feePoolStaking.migrateUserMappings(_epoch, startIndex, endIndex, _user, _epochToUserStakedWeight, _userRewardsClaimed);
+        feePoolStaking.migrateUserMappings(
+            _epoch, startIndex, endIndex, _user, _epochToUserStakedWeight, _userRewardsClaimed
+        );
 
         // Verifying user data
         for (uint256 i = startIndex; i < endIndex; ++i) {
@@ -95,7 +108,13 @@ contract MigrateUserMappings_Test is BasePushFeePoolStaking {
         }
     }
 
-    function getActualEpochToUserStakedWeight(address user, uint256 epoch) public returns (uint256 epochToWeightValue) {
+    function getActualEpochToUserStakedWeight(
+        address user,
+        uint256 epoch
+    )
+        public
+        returns (uint256 epochToWeightValue)
+    {
         uint256 userFeesInfoMappingSlot = 11;
         bytes32 userFeesInfoSlotHash = keccak256(abi.encode(user, userFeesInfoMappingSlot));
 


### PR DESCRIPTION
This PR includes some additional fixes in the implementation of custom errors for Push Contracts

- Included a Librarary of errors.
- Classification of different errors in the librarary based on the type of contracts. 
- Rewrote errors and added a few new ones
- Removed dynamic string from custom error params as it consumes more gas and is ineffective
- Releveant changes can also be found in Core, Comm and Staking contracts
- Included natspec for all errors.