### PR TITLE
chore: fix h1 vunerability

### DIFF
--- a/contracts/PushComm/PushCommV2.sol
+++ b/contracts/PushComm/PushCommV2.sol
@@ -775,6 +775,13 @@ contract PushCommV2 is Initializable, PushCommStorageV2 {
         require(amount > 0, "Request cannot be initiated without deposit");
         address requestSender = msg.sender;
         address coreContract = EPNSCoreAddress;
+        
+        // Verify that requestSender has permission to transfer the tokens
+        require(
+        IERC20(PUSH_TOKEN_ADDRESS).allowance(requestSender, address(this)) >= amount,
+        "PushCommV2: transfer amount exceeds allowance"
+        );
+
         // Transfer incoming PUSH Token to core contract
         IERC20(PUSH_TOKEN_ADDRESS).safeTransferFrom(
             requestSender,

--- a/contracts/PushCore/PushCoreV2.sol
+++ b/contracts/PushCore/PushCoreV2.sol
@@ -282,6 +282,11 @@ contract PushCoreV2 is
         channelUpdateCounter[_channel] = updateCounter;
         channels[_channel].channelUpdateBlock = block.number;
 
+        require(
+            IERC20(PUSH_TOKEN_ADDRESS).allowance(_channel, address(this)) >= _amount,
+            "PushCoreV2: transfer amount exceeds allowance"
+        );
+
         IERC20(PUSH_TOKEN_ADDRESS).safeTransferFrom(
             _channel,
             address(this),


### PR DESCRIPTION
## H-1: Arbitrary `from` passed to `transferFrom` (or `safeTransferFrom`)

Passing an arbitrary `from` address to `transferFrom` (or `safeTransferFrom`) can lead to loss of funds, because anyone can transfer tokens from the `from` address if an approval is made.  

- Found in contracts/PushComm/PushCommV2.sol [Line: 779](contracts/PushComm/PushCommV2.sol#L779)

	```solidity
	        IERC20(PUSH_TOKEN_ADDRESS).safeTransferFrom(
	```

- Found in contracts/PushCore/PushCoreV2.sol [Line: 285](contracts/PushCore/PushCoreV2.sol#L285)

	```solidity
	        IERC20(PUSH_TOKEN_ADDRESS).safeTransferFrom(
	```
