### PR TITLE
230 migrate comm unit tests

### DIFF
--- a/contracts/PushComm/PushCommV2_5.sol
+++ b/contracts/PushComm/PushCommV2_5.sol
@@ -569,7 +569,7 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2 {
         private
         returns (bool)
     {
-        if (_channel == _signatory || delegatedNotificationSenders[_channel][_signatory] || _recipient == _signatory) {
+        if (_channel == _signatory || delegatedNotificationSenders[_channel][_signatory] ) {
             // Emit the message out
             emit SendNotification(_channel, _recipient, _identity);
             return true;

--- a/testFoundry/BaseTest.t.sol
+++ b/testFoundry/BaseTest.t.sol
@@ -42,6 +42,7 @@ abstract contract BaseTest is Test, Constants, CoreEvents {
     uint256 FEE_AMOUNT = 10 ether;
     uint256 MIN_POOL_CONTRIBUTION = 50 ether; 
     uint256 ADJUST_FOR_FLOAT = 10 ** 7;
+    mapping(address => uint) privateKeys;
 
     /* ***************
        Initializing Set-Up for Push Contracts
@@ -124,12 +125,16 @@ abstract contract BaseTest is Test, Constants, CoreEvents {
     }
 
     function createActor(string memory name) internal returns (address payable) {
-        address payable actor = payable(makeAddr(name));
+        address actor;
+        uint Private;
+        (actor, Private) = makeAddrAndKey(name);
+        address payable _actor = payable(actor);
+        privateKeys[actor] = Private;
         // Transfer 50 eth to every actor
-        vm.deal({ account: actor, newBalance: 50 ether });
+        vm.deal({ account: _actor, newBalance: 50 ether });
         // Transfer 50K PUSH Tokens for every actor
         vm.prank(tokenDistributor);
-        pushToken.transfer(actor, 50_000 ether);
-        return actor;
+        pushToken.transfer(_actor, 50_000 ether);
+        return _actor;
     }
 }

--- a/testFoundry/PushComm/unit_tests/SendingNotifications/SendNotifs.t.sol
+++ b/testFoundry/PushComm/unit_tests/SendingNotifications/SendNotifs.t.sol
@@ -1,0 +1,95 @@
+pragma solidity ^0.8.0;
+import {BaseTest} from "../../../BaseTest.t.sol";
+import {PushCoreStorageV1_5} from "contracts/PushCore/PushCoreStorageV1_5.sol";
+
+// import "forge-std/console.sol";
+contract SendNotifs_Test is BaseTest {
+    bytes constant _testChannelIdentity = bytes("test-channel-hello-world");
+
+    function setUp() public override {
+        BaseTest.setUp();
+        changePrank(actor.bob_channel_owner);
+        coreProxy.createChannelWithPUSH(
+            PushCoreStorageV1_5.ChannelType.InterestBearingOpen,
+            _testChannelIdentity,
+            50e18,
+            0
+        );
+    }
+
+    function test_WhenAUserIsSendingNotifToOtherAddressInsteadOfThemselves()
+        external
+    {
+        changePrank(actor.charlie_channel_owner);
+        bool res = commProxy.sendNotification(
+            actor.bob_channel_owner,
+            actor.alice_channel_owner,
+            _testChannelIdentity
+        );
+        assertEq(res, false);
+    }
+
+    function test_WhenRecipientIsSendingNOTIFOnlyToThemselves() external {
+        //User can no longer send notifs to themselves
+    }
+
+    function test_WhenChannelIs0x00ButCallerIsAnyAddressOtherThanAdminOrGovernance()
+        external
+    {
+        changePrank(actor.charlie_channel_owner);
+        bool res = commProxy.sendNotification(
+            address(0),
+            actor.alice_channel_owner,
+            _testChannelIdentity
+        );
+        assertEq(res, false);
+    }
+
+    function test_WhenChannelIs0x00AndCallerIsAdminOrGovernance() external {
+        changePrank(actor.admin);
+        bool res = commProxy.sendNotification(
+            address(0),
+            actor.alice_channel_owner,
+            _testChannelIdentity
+        );
+        assertEq(res, true);
+    }
+
+    function test_WhenDelegateSendNotificationWithoutApproval() external {
+        bool isTonyDelegate = commProxy.delegatedNotificationSenders(
+            actor.bob_channel_owner,
+            actor.dan_push_holder
+        );
+
+        assertEq(isTonyDelegate, false);
+
+        changePrank(actor.dan_push_holder);
+        bool res = commProxy.sendNotification(
+            actor.bob_channel_owner,
+            actor.alice_channel_owner,
+            _testChannelIdentity
+        );
+        assertEq(res, false);
+    }
+
+    function test_WhenAllowedDelagtesSendsNotificationToAnyRecipient()
+        external
+    {
+        changePrank(actor.bob_channel_owner);
+        commProxy.addDelegate(actor.dan_push_holder);
+        bool isTonyDelegate = commProxy.delegatedNotificationSenders(
+            actor.bob_channel_owner,
+            actor.dan_push_holder
+        );
+
+        assertEq(isTonyDelegate, true);
+
+        changePrank(actor.dan_push_holder);
+        bool res = commProxy.sendNotification(
+            actor.bob_channel_owner,
+            actor.alice_channel_owner,
+            _testChannelIdentity
+        );
+        assertEq(res, true);
+    }
+}

--- a/testFoundry/PushComm/unit_tests/SendingNotifications/SendNotifs.tree
+++ b/testFoundry/PushComm/unit_tests/SendingNotifications/SendNotifs.tree
@@ -1,0 +1,14 @@
+SendNotifs_Test
+├── when a User is sending Notif to Other Address Instead of themselves
+│   └── it Should return false
+├── when Recipient is Sending NOTIF Only to themselves
+│   └── it Should Emit Event
+├── when Channel is 0x00 But Caller is any address other than Admin or Governance
+│   └── it Should return false
+├── when Channel is 0x00 and Caller is Admin or Governance
+│   └── it Should Emit Event
+├── when Delegate without send notification without Approval
+│   └── it Should return false
+└── when Allowed Delagtes Sends Notification to any Recipient
+    └── it Should Emit Event
+    

--- a/testFoundry/PushComm/unit_tests/SendingNotifications/SendNotifsViaSig.t.sol
+++ b/testFoundry/PushComm/unit_tests/SendingNotifications/SendNotifsViaSig.t.sol
@@ -1,0 +1,248 @@
+pragma solidity ^0.8.0;
+import {BaseTest} from "../../../BaseTest.t.sol";
+import {PushCoreStorageV1_5} from "contracts/PushCore/PushCoreStorageV1_5.sol";
+import {SignatureVerifier} from "contracts/mocks/MockERC1271.sol";
+import "forge-std/console.sol";
+
+contract SendNotifsViaSig_Test is BaseTest {
+    bytes32 public constant DOMAIN_TYPEHASH =
+        keccak256(
+            "EIP712Domain(string name,uint256 chainId,address verifyingContract)"
+        );
+
+    // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 public constant SEND_NOTIFICATION_TYPEHASH =
+        keccak256(
+            "SendNotification(address channel,address recipient,bytes identity,uint256 nonce,uint256 expiry)"
+        );
+
+    bytes32 public constant NAME_HASH = keccak256(bytes("EPNS COMM V1"));
+
+    bytes constant _testChannelIdentity = bytes("test-channel-hello-world");
+
+    SignatureVerifier verifierContract;
+
+    function setUp() public override {
+        BaseTest.setUp();
+        changePrank(actor.tim_push_holder);
+        verifierContract = new SignatureVerifier();
+
+        changePrank(actor.bob_channel_owner);
+        coreProxy.createChannelWithPUSH(
+            PushCoreStorageV1_5.ChannelType.InterestBearingOpen,
+            _testChannelIdentity,
+            50e18,
+            0
+        );
+    }
+
+    function test_WhenChannelSendsNotificationuUsing712Sig() external {
+        // it Allows to send channel notification with 712 sig
+        bytes32 DOMAIN_SEPARATOR = getDomainSeparator();
+
+        SendNotif memory _sendNotif = SendNotif(
+            actor.bob_channel_owner,
+            actor.alice_channel_owner,
+            _testChannelIdentity,
+            commProxy.nonces(actor.bob_channel_owner),
+            block.timestamp + 1000
+        );
+        bytes32 structHash = getStructHash(_sendNotif);
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKeys[actor.bob_channel_owner], digest);
+
+        bool res = commProxy.sendNotifBySig(
+            actor.bob_channel_owner,
+            actor.alice_channel_owner,
+            actor.bob_channel_owner,
+            _testChannelIdentity,
+            commProxy.nonces(actor.bob_channel_owner),
+            block.timestamp + 1000,
+            v,
+            r,
+            s
+        );
+
+        assertEq(true, res);
+    }
+
+    function test_WhenDelegateeSendsNotificationUsing712Sig() external {
+        // it Allows delegatee to send notification
+
+        changePrank(actor.bob_channel_owner);
+        commProxy.addDelegate(actor.charlie_channel_owner);
+
+        bytes32 DOMAIN_SEPARATOR = getDomainSeparator();
+        SendNotif memory _sendNotif = SendNotif(
+            actor.bob_channel_owner,
+            actor.alice_channel_owner,
+            _testChannelIdentity,
+            commProxy.nonces(actor.charlie_channel_owner),
+            block.timestamp + 1000
+        );
+        bytes32 structHash = getStructHash(_sendNotif);
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKeys[actor.charlie_channel_owner], digest);
+
+        bool res = commProxy.sendNotifBySig(
+            actor.bob_channel_owner,
+            actor.alice_channel_owner,
+            actor.charlie_channel_owner,
+            _testChannelIdentity,
+            commProxy.nonces(actor.charlie_channel_owner),
+            block.timestamp + 1000,
+            v,
+            r,
+            s
+        );
+
+        assertEq(true, res);
+    }
+
+    function test_WhenCalledUsingA1271Sig() external {
+        // it Allow to send channel notification with 1271 sig
+        bytes32 DOMAIN_SEPARATOR = getDomainSeparator();
+        SendNotif memory _sendNotif = SendNotif(
+            address(verifierContract),
+            actor.alice_channel_owner,
+            _testChannelIdentity,
+            commProxy.nonces(address(verifierContract)),
+            block.timestamp + 1000
+        );
+        bytes32 structHash = getStructHash(_sendNotif);
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKeys[actor.tim_push_holder], digest);
+
+        bool res = commProxy.sendNotifBySig(
+            address(verifierContract),
+            actor.alice_channel_owner,
+            address(verifierContract),
+            _testChannelIdentity,
+            commProxy.nonces(address(verifierContract)),
+            block.timestamp + 1000,
+            v,
+            r,
+            s
+        );
+
+        assertEq(true, res);
+    }
+
+    function test_WhenInvokedByAMaliciousUserUsingSignatureReplay() external {
+        // it Returns false on signature replay
+        bytes32 DOMAIN_SEPARATOR = getDomainSeparator();
+        SendNotif memory _sendNotif = SendNotif(
+            address(verifierContract),
+            actor.alice_channel_owner,
+            _testChannelIdentity,
+            commProxy.nonces(address(verifierContract)),
+            block.timestamp + 1000
+        );
+        bytes32 structHash = getStructHash(_sendNotif);
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKeys[actor.tim_push_holder], digest);
+        //Notification already sent one time
+        commProxy.sendNotifBySig(
+            address(verifierContract),
+            actor.alice_channel_owner,
+            address(verifierContract),
+            _testChannelIdentity,
+            commProxy.nonces(address(verifierContract)),
+            block.timestamp + 1000,
+            v,
+            r,
+            s
+        );
+
+        //Using the same signature twice should fail
+        bool res = commProxy.sendNotifBySig(
+            address(verifierContract),
+            actor.alice_channel_owner,
+            address(verifierContract),
+            _testChannelIdentity,
+            commProxy.nonces(address(verifierContract)),
+            block.timestamp + 1000,
+            v,
+            r,
+            s
+        );
+        assertEq(false, res);
+    }
+
+    function test_WhenInvokedByAMaliciousUserUsingExpiredSignature() external {
+        // it Returns false on signature expire
+        bytes32 DOMAIN_SEPARATOR = getDomainSeparator();
+        SendNotif memory _sendNotif = SendNotif(
+            address(verifierContract),
+            actor.alice_channel_owner,
+            _testChannelIdentity,
+            commProxy.nonces(address(verifierContract)),
+            block.timestamp + 1000
+        );
+        bytes32 structHash = getStructHash(_sendNotif);
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKeys[actor.tim_push_holder], digest);
+
+        bool res = commProxy.sendNotifBySig(
+            address(verifierContract),
+            actor.alice_channel_owner,
+            address(verifierContract),
+            _testChannelIdentity,
+            commProxy.nonces(address(verifierContract)),
+            block.timestamp - 1,
+            v,
+            r,
+            s
+        );
+
+        assertEq(false, res);
+    }
+
+    //HELPER FUNCTIONS
+    struct SendNotif {
+        address _channel;
+        address _recipient;
+        bytes _identity;
+        uint nonce;
+        uint expiry;
+    }
+
+    // computes the hash of a sendNotif
+    function getStructHash(
+        SendNotif memory _sendNotif
+    ) internal pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    SEND_NOTIFICATION_TYPEHASH,
+                    _sendNotif._channel,
+                    _sendNotif._recipient,
+                    keccak256(_sendNotif._identity),
+                    _sendNotif.nonce,
+                    _sendNotif.expiry
+                )
+            );
+    }
+
+    function getDomainSeparator() public returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    DOMAIN_TYPEHASH,
+                    NAME_HASH,
+                    block.chainid,
+                    address(commProxy)
+                )
+            );
+    }
+}

--- a/testFoundry/PushComm/unit_tests/SendingNotifications/SendNotifsViaSig.t.sol
+++ b/testFoundry/PushComm/unit_tests/SendingNotifications/SendNotifsViaSig.t.sol
@@ -2,22 +2,8 @@ pragma solidity ^0.8.0;
 import {BaseTest} from "../../../BaseTest.t.sol";
 import {PushCoreStorageV1_5} from "contracts/PushCore/PushCoreStorageV1_5.sol";
 import {SignatureVerifier} from "contracts/mocks/MockERC1271.sol";
-import "forge-std/console.sol";
 
 contract SendNotifsViaSig_Test is BaseTest {
-    bytes32 public constant DOMAIN_TYPEHASH =
-        keccak256(
-            "EIP712Domain(string name,uint256 chainId,address verifyingContract)"
-        );
-
-    // keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
-    bytes32 public constant SEND_NOTIFICATION_TYPEHASH =
-        keccak256(
-            "SendNotification(address channel,address recipient,bytes identity,uint256 nonce,uint256 expiry)"
-        );
-
-    bytes32 public constant NAME_HASH = keccak256(bytes("EPNS COMM V1"));
-
     bytes constant _testChannelIdentity = bytes("test-channel-hello-world");
 
     SignatureVerifier verifierContract;

--- a/testFoundry/PushComm/unit_tests/SendingNotifications/SendNotifsViaSig.tree
+++ b/testFoundry/PushComm/unit_tests/SendingNotifications/SendNotifsViaSig.tree
@@ -1,0 +1,11 @@
+SendNotifsViaSig_Test
+├── when channel sends notificationu using 712 sig
+│   └── it Allows to send channel notification with 712 sig
+├── when delegatee sends notification using 712 sig
+│   └── it Allows delegatee to send notification
+├── when called using a 1271 sig
+│   └── it Allow to send channel notification with 1271 sig
+├── when invoked by a malicious user using signature replay
+│   └── it Returns false on signature replay
+└── when invoked by a malicious user using expired signature
+    └── it      Returns false on signature expire

--- a/testFoundry/PushComm/unit_tests/SubscribeBySig/SubscribeBySig.t.sol
+++ b/testFoundry/PushComm/unit_tests/SubscribeBySig/SubscribeBySig.t.sol
@@ -1,0 +1,422 @@
+pragma solidity ^0.8.0;
+import {BaseTest} from "../../../BaseTest.t.sol";
+import {PushCoreStorageV1_5} from "contracts/PushCore/PushCoreStorageV1_5.sol";
+import {SignatureVerifier} from "contracts/mocks/MockERC1271.sol";
+
+import "forge-std/console.sol";
+
+contract SubscribeBySig_Test is BaseTest {
+    bytes constant _testChannelIdentity = bytes("test-channel-hello-world");
+    event Subscribe(address indexed channel, address indexed user);
+    event Unsubscribe(address indexed channel, address indexed user);
+
+    SignatureVerifier verifierContract;
+
+    function setUp() public override {
+        BaseTest.setUp();
+
+        changePrank(actor.tim_push_holder);
+        verifierContract = new SignatureVerifier();
+
+        changePrank(actor.bob_channel_owner);
+        coreProxy.createChannelWithPUSH(
+            PushCoreStorageV1_5.ChannelType.InterestBearingOpen,
+            _testChannelIdentity,
+            50e18,
+            0
+        );
+    }
+
+    modifier whenUserSubscribesWith712Sig() {
+        _;
+    }
+
+    function test_WhenMaliciousUserReplaysA712Signature()
+        public
+        whenUserSubscribesWith712Sig
+    {
+        bytes32 DOMAIN_SEPARATOR = getDomainSeparator();
+        SubscribeUnsubscribe
+            memory _subscribeUnsubscribe = SubscribeUnsubscribe(
+                actor.bob_channel_owner,
+                actor.alice_channel_owner,
+                commProxy.nonces(actor.alice_channel_owner),
+                block.timestamp + 1000
+            );
+        bytes32 structHash = getStructHash(
+            _subscribeUnsubscribe,
+            SUBSCRIBE_TYPEHASH
+        );
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+            privateKeys[actor.alice_channel_owner],
+            digest
+        );
+        console.log(commProxy.nonces(actor.alice_channel_owner));
+
+        commProxy.subscribeBySig(
+            actor.bob_channel_owner,
+            actor.alice_channel_owner,
+            commProxy.nonces(actor.alice_channel_owner),
+            block.timestamp + 1000,
+            v,
+            r,
+            s
+        );
+        changePrank(actor.charlie_channel_owner);
+
+        vm.expectRevert(bytes("PushCommV2::subscribeBySig: Invalid nonce"));
+        commProxy.subscribeBySig(
+            actor.bob_channel_owner,
+            actor.alice_channel_owner,
+            commProxy.nonces(actor.alice_channel_owner) - 1,
+            block.timestamp + 1000,
+            v,
+            r,
+            s
+        );
+    }
+
+    function test_WhenAnExpired712SignatureIsPassed()
+        public
+        whenUserSubscribesWith712Sig
+    {
+        bytes32 DOMAIN_SEPARATOR = getDomainSeparator();
+        SubscribeUnsubscribe
+            memory _subscribeUnsubscribe = SubscribeUnsubscribe(
+                actor.bob_channel_owner,
+                actor.alice_channel_owner,
+                commProxy.nonces(actor.alice_channel_owner),
+                block.timestamp - 10
+            );
+        bytes32 structHash = getStructHash(
+            _subscribeUnsubscribe,
+            SUBSCRIBE_TYPEHASH
+        );
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+            privateKeys[actor.alice_channel_owner],
+            digest
+        );
+        changePrank(actor.charlie_channel_owner);
+
+        vm.expectRevert();
+        commProxy.subscribeBySig(
+            actor.bob_channel_owner,
+            actor.alice_channel_owner,
+            commProxy.nonces(actor.alice_channel_owner),
+            block.timestamp - 10,
+            v,
+            r,
+            s
+        );
+    }
+
+    function test_WhenThe712SignIsCorrect()
+        public
+        whenUserSubscribesWith712Sig
+    {
+        bytes32 DOMAIN_SEPARATOR = getDomainSeparator();
+        SubscribeUnsubscribe
+            memory _subscribeUnsubscribe = SubscribeUnsubscribe(
+                actor.bob_channel_owner,
+                actor.alice_channel_owner,
+                commProxy.nonces(actor.alice_channel_owner),
+                block.timestamp + 100
+            );
+        bytes32 structHash = getStructHash(
+            _subscribeUnsubscribe,
+            SUBSCRIBE_TYPEHASH
+        );
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+            privateKeys[actor.alice_channel_owner],
+            digest
+        );
+        vm.expectEmit(true, true, false, false);
+        emit Subscribe(actor.bob_channel_owner, actor.alice_channel_owner);
+        commProxy.subscribeBySig(
+            actor.bob_channel_owner,
+            actor.alice_channel_owner,
+            commProxy.nonces(actor.alice_channel_owner),
+            block.timestamp + 100,
+            v,
+            r,
+            s
+        );
+    }
+
+    modifier whenAContractSubscribesWith1271Sign() {
+        _;
+    }
+
+    function test_WhenMaliciousUserReplaysA1271Sig()
+        public
+        whenAContractSubscribesWith1271Sign
+    {
+        bytes32 DOMAIN_SEPARATOR = getDomainSeparator();
+        SubscribeUnsubscribe
+            memory _subscribeUnsubscribe = SubscribeUnsubscribe(
+                actor.bob_channel_owner,
+                address(verifierContract),
+                commProxy.nonces(address(verifierContract)),
+                block.timestamp + 100
+            );
+        bytes32 structHash = getStructHash(
+            _subscribeUnsubscribe,
+            SUBSCRIBE_TYPEHASH
+        );
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+            privateKeys[actor.tim_push_holder],
+            digest
+        );
+        vm.expectEmit(true, true, false, false);
+        emit Subscribe(actor.bob_channel_owner, address(verifierContract));
+        commProxy.subscribeBySig(
+            actor.bob_channel_owner,
+            address(verifierContract),
+            commProxy.nonces(address(verifierContract)),
+            block.timestamp + 100,
+            v,
+            r,
+            s
+        );
+
+        changePrank(actor.charlie_channel_owner);
+        // vm.expectRevert();
+        commProxy.subscribeBySig(
+            actor.bob_channel_owner,
+            address(verifierContract),
+            commProxy.nonces(address(verifierContract)) - 1,
+            block.timestamp + 100,
+            v,
+            r,
+            s
+        );
+    }
+
+    function test_WhenAnExpired1271SigIsPassed()
+        public
+        whenAContractSubscribesWith1271Sign
+    {
+        bytes32 DOMAIN_SEPARATOR = getDomainSeparator();
+        SubscribeUnsubscribe
+            memory _subscribeUnsubscribe = SubscribeUnsubscribe(
+                actor.bob_channel_owner,
+                address(verifierContract),
+                commProxy.nonces(address(verifierContract)),
+                block.timestamp - 100
+            );
+        bytes32 structHash = getStructHash(
+            _subscribeUnsubscribe,
+            SUBSCRIBE_TYPEHASH
+        );
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+            privateKeys[actor.tim_push_holder],
+            digest
+        );
+
+        changePrank(actor.charlie_channel_owner);
+        vm.expectRevert();
+        commProxy.subscribeBySig(
+            actor.bob_channel_owner,
+            address(verifierContract),
+            commProxy.nonces(address(verifierContract)),
+            block.timestamp - 100,
+            v,
+            r,
+            s
+        );
+    }
+
+    function test_WhenThe1271SignIsCorrect()
+        public
+        whenAContractSubscribesWith1271Sign
+    {
+        bytes32 DOMAIN_SEPARATOR = getDomainSeparator();
+        SubscribeUnsubscribe
+            memory _subscribeUnsubscribe = SubscribeUnsubscribe(
+                actor.bob_channel_owner,
+                address(verifierContract),
+                commProxy.nonces(address(verifierContract)),
+                block.timestamp + 100
+            );
+        bytes32 structHash = getStructHash(
+            _subscribeUnsubscribe,
+            SUBSCRIBE_TYPEHASH
+        );
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+            privateKeys[actor.tim_push_holder],
+            digest
+        );
+        vm.expectEmit(true, true, false, false);
+        emit Subscribe(actor.bob_channel_owner, address(verifierContract));
+        commProxy.subscribeBySig(
+            actor.bob_channel_owner,
+            address(verifierContract),
+            commProxy.nonces(address(verifierContract)),
+            block.timestamp + 100,
+            v,
+            r,
+            s
+        );
+    }
+
+    function test_WhenUsersUnsubscribeWith712Sig() public {
+        //Alice subscribes to bob's channel to check the unsubscribe function
+        changePrank(actor.alice_channel_owner);
+        bool res = commProxy.subscribe(actor.bob_channel_owner);
+        assertEq(res, true);
+
+        bytes32 DOMAIN_SEPARATOR = getDomainSeparator();
+        SubscribeUnsubscribe
+            memory _subscribeUnsubscribe = SubscribeUnsubscribe(
+                actor.bob_channel_owner,
+                actor.alice_channel_owner,
+                commProxy.nonces(actor.alice_channel_owner),
+                block.timestamp + 100
+            );
+        bytes32 structHash = getStructHash(
+            _subscribeUnsubscribe,
+            UNSUBSCRIBE_TYPEHASH
+        );
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+            privateKeys[actor.alice_channel_owner],
+            digest
+        );
+        vm.expectEmit(true, true, false, false);
+        emit Unsubscribe(actor.bob_channel_owner, actor.alice_channel_owner);
+        commProxy.unsubscribeBySig(
+            actor.bob_channel_owner,
+            actor.alice_channel_owner,
+            commProxy.nonces(actor.alice_channel_owner),
+            block.timestamp + 100,
+            v,
+            r,
+            s
+        );
+    }
+
+    function test_WhenAContractUnsubscribesWith1271Sig() public {
+        // it Allow contract to optout using 1271 support
+
+        //The contract subscribes to a channel
+        bytes32 DOMAIN_SEPARATOR = getDomainSeparator();
+        SubscribeUnsubscribe
+            memory _subscribeUnsubscribe = SubscribeUnsubscribe(
+                actor.bob_channel_owner,
+                address(verifierContract),
+                commProxy.nonces(address(verifierContract)),
+                block.timestamp + 100
+            );
+        bytes32 structHash = getStructHash(
+            _subscribeUnsubscribe,
+            SUBSCRIBE_TYPEHASH
+        );
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+            privateKeys[actor.tim_push_holder],
+            digest
+        );
+        vm.expectEmit(true, true, false, false);
+        emit Subscribe(actor.bob_channel_owner, address(verifierContract));
+        commProxy.subscribeBySig(
+            actor.bob_channel_owner,
+            address(verifierContract),
+            commProxy.nonces(address(verifierContract)),
+            block.timestamp + 100,
+            v,
+            r,
+            s
+        );
+
+        //check the unsubscribe function
+        bytes32 DOMAIN_SEPARATOR1 = getDomainSeparator();
+        SubscribeUnsubscribe
+            memory _subscribeUnsubscribe1 = SubscribeUnsubscribe(
+                actor.bob_channel_owner,
+                address(verifierContract),
+                commProxy.nonces(address(verifierContract)),
+                block.timestamp + 100
+            );
+        bytes32 structHash1 = getStructHash(
+            _subscribeUnsubscribe1,
+            UNSUBSCRIBE_TYPEHASH
+        );
+        bytes32 digest1 = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR1, structHash1)
+        );
+        (uint8 v1, bytes32 r1, bytes32 s1) = vm.sign(
+            privateKeys[actor.tim_push_holder],
+            digest1
+        );
+        vm.expectEmit(true, true, false, false);
+        emit Unsubscribe(actor.bob_channel_owner, address(verifierContract));
+        commProxy.unsubscribeBySig(
+            actor.bob_channel_owner,
+            address(verifierContract),
+            commProxy.nonces(address(verifierContract)),
+            block.timestamp + 100,
+            v1,
+            r1,
+            s1
+        );
+    }
+
+    //Helper Functions
+    struct SubscribeUnsubscribe {
+        address _channel;
+        address _subscriber;
+        uint nonce;
+        uint expiry;
+    }
+
+    // computes the hash of a sendNotif
+    function getStructHash(
+        SubscribeUnsubscribe memory _subscribeUnsubscribe,
+        bytes32 _typehash
+    ) internal pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    _typehash,
+                    _subscribeUnsubscribe._channel,
+                    _subscribeUnsubscribe._subscriber,
+                    _subscribeUnsubscribe.nonce,
+                    _subscribeUnsubscribe.expiry
+                )
+            );
+    }
+
+    function getDomainSeparator() public returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    DOMAIN_TYPEHASH,
+                    NAME_HASH,
+                    block.chainid,
+                    address(commProxy)
+                )
+            );
+    }
+}

--- a/testFoundry/PushComm/unit_tests/SubscribeBySig/SubscribeBySig.tree
+++ b/testFoundry/PushComm/unit_tests/SubscribeBySig/SubscribeBySig.tree
@@ -1,0 +1,19 @@
+SubscribeBySig_Test
+├── when user subscribes with 712 sig
+│   ├── when malicious user replays a 712 signature
+│   │   └── it Reverts on signature replay
+│   ├── when an expired 712 signature is passed
+│   │   └── it Reverts on signature expiry
+│   └── when the 712 sign is correct
+│       └── it Allows to optin with 712 sig
+├── when a contract subscribes with 1271 sign
+│   ├── when malicious user replays a 1271 sig
+│   │   └── it Reverts on signature replay
+│   ├── when an expired 1271 sig is passed
+│   │   └── it Reverts on signature expiry
+│   └── when the 1271 sign is correct
+│       └── it Allow to contract to optin using 1271 support
+├── when       users unsubscribe with 712 sig
+│   └── it Allows to optout with 712 sig
+└── when a contract unsubscribes with 1271 sig
+    └── it Allow contract to optout using 1271 support

--- a/testFoundry/utils/Constants.sol
+++ b/testFoundry/utils/Constants.sol
@@ -12,4 +12,16 @@ abstract contract Constants {
     uint256 public totalStakedAmount = 6_654_086 ether;
     uint256 public previouslySetEpochRewards = 60_000 ether;
     uint256 public constant epochDuration = 21 * 7156; // 21 * number of blocks per day(7156) ~ 20 day approx
+
+    //Comm Constants used for meta transaction
+    string public constant name = "EPNS COMM V1";
+        bytes32 public constant NAME_HASH = keccak256(bytes(name));
+    bytes32 public constant DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)");
+    bytes32 public constant SUBSCRIBE_TYPEHASH =
+        keccak256("Subscribe(address channel,address subscriber,uint256 nonce,uint256 expiry)");
+    bytes32 public constant UNSUBSCRIBE_TYPEHASH =
+        keccak256("Unsubscribe(address channel,address subscriber,uint256 nonce,uint256 expiry)");
+    bytes32 public constant SEND_NOTIFICATION_TYPEHASH =
+        keccak256("SendNotification(address channel,address recipient,bytes identity,uint256 nonce,uint256 expiry)");
 }


### PR DESCRIPTION
Includes the Foundry tests for Comm Contract. 
Partially Solves https://github.com/ethereum-push-notification-service/push-smart-contracts/issues/230