### PR TITLE
Fixes updatechannel meta and only channel owner

### DIFF
--- a/contracts/PushCore/PushCoreV2_5.sol
+++ b/contracts/PushCore/PushCoreV2_5.sol
@@ -185,7 +185,7 @@ contract PushCoreV2_5 is Initializable, PushCoreStorageV1_5, PausableUpgradeable
         channelUpdateCounter[_channel] = updateCounter;
         channels[_channel].channelUpdateBlock = block.number;
 
-        IERC20(PUSH_TOKEN_ADDRESS).safeTransferFrom(_channel, address(this), _amount);
+        IERC20(PUSH_TOKEN_ADDRESS).safeTransferFrom(msg.sender, address(this), _amount);
         emit UpdateChannel(_channel, _newIdentity, _amount);
     }
 

--- a/contracts/PushCore/PushCoreV2_Temp.sol
+++ b/contracts/PushCore/PushCoreV2_Temp.sol
@@ -93,10 +93,8 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
 
     function onlyChannelOwner(address _channel) private view {
         if (
-            (
-                (channels[_channel].channelState != 1 || msg.sender != _channel)
-                    || (msg.sender != pushChannelAdmin && _channel == address(0x0))
-            )
+            !((channels[_channel].channelState == 1 && msg.sender == _channel) ||
+                (msg.sender == pushChannelAdmin && _channel == address(0x0)))
         ) {
             revert Errors.UnauthorizedCaller(msg.sender);
         }
@@ -207,7 +205,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
         channelUpdateCounter[_channel] = updateCounter;
         channels[_channel].channelUpdateBlock = block.number;
 
-        IERC20(PUSH_TOKEN_ADDRESS).safeTransferFrom(_channel, address(this), _amount);
+        IERC20(PUSH_TOKEN_ADDRESS).safeTransferFrom(msg.sender, address(this), _amount);
         emit UpdateChannel(_channel, _newIdentity, _amount);
     }
 

--- a/testFoundry/PushCore/unit_tests/ChannelUpdation/updateChannelMeta.tree
+++ b/testFoundry/PushCore/unit_tests/ChannelUpdation/updateChannelMeta.tree
@@ -13,4 +13,4 @@ updateChannelMeta.t.sol
                 └── when amount passed is accurate
                     ├── it should update the channel successfully
                     ├── it should update variables correctly
-                    └── fees should increase linearly for every update
+                    └── it should increase the fees linearly for every update


### PR DESCRIPTION
Solves https://github.com/ethereum-push-notification-service/push-smart-contracts/issues/242 and https://github.com/ethereum-push-notification-service/push-smart-contracts/issues/240