### PR TITLE
Added Admin-Only test cases

### DIFF
--- a/contracts/PushCore/PushCoreV2_5.sol
+++ b/contracts/PushCore/PushCoreV2_5.sol
@@ -121,8 +121,9 @@ contract PushCoreV2_5 is Initializable, PushCoreStorageV1_5, PausableUpgradeable
      *
      * @dev    _newFees must not be more than (or equal to) the ADD_CHANNEL_MIN_FEES
      *
-     * @param _newFees new minimum fees required for FEE_AMOUNT 
+     * @param _newFees new minimum fees required for FEE_AMOUNT
      */
+
     function setFeeAmount(uint256 _newFees) external {
         onlyGovernance();
         if (_newFees >= ADD_CHANNEL_MIN_FEES) {
@@ -152,7 +153,7 @@ contract PushCoreV2_5 is Initializable, PushCoreStorageV1_5, PausableUpgradeable
     /**
      * @notice Allows to set the Minimum amount threshold for Creating Channels
      *
-     * @dev    Minimum required amount can never be below the sum of MIN_POOL_CONTRIBUTION and FEE_AMOUNT 
+     * @dev    Minimum required amount can never be below the sum of MIN_POOL_CONTRIBUTION and FEE_AMOUNT
      *
      * @param _newFees new minimum fees required for Channel Creation
      *
@@ -308,7 +309,7 @@ contract PushCoreV2_5 is Initializable, PushCoreStorageV1_5, PausableUpgradeable
         uint256 totalRefundableAmount = channelData.poolContribution;
         // Update POOL_FUNDS & PROTOCOL_POOL_FEES
         CHANNEL_POOL_FUNDS = CHANNEL_POOL_FUNDS - totalRefundableAmount;
-        
+
         if (msg.sender != pushChannelAdmin) {
             IERC20(PUSH_TOKEN_ADDRESS).safeTransfer(msg.sender, totalRefundableAmount);
         } else {

--- a/contracts/PushCore/PushCoreV2_Temp.sol
+++ b/contracts/PushCore/PushCoreV2_Temp.sol
@@ -121,8 +121,9 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
      *
      * @dev    _newFees must not be more than (or equal to) the ADD_CHANNEL_MIN_FEES
      *
-     * @param _newFees new minimum fees required for FEE_AMOUNT 
+     * @param _newFees new minimum fees required for FEE_AMOUNT
      */
+
     function setFeeAmount(uint256 _newFees) external {
         onlyGovernance();
         if (_newFees >= ADD_CHANNEL_MIN_FEES) {
@@ -151,11 +152,12 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
     /**
      * @notice Allows to set the Minimum amount threshold for Creating Channels
      *
-     * @dev    Minimum required amount can never be below the sum of MIN_POOL_CONTRIBUTION and FEE_AMOUNT 
+     * @dev    Minimum required amount can never be below the sum of MIN_POOL_CONTRIBUTION and FEE_AMOUNT
      *
      * @param _newFees new minimum fees required for Channel Creation
      *
      */
+
     function setMinChannelCreationFees(uint256 _newFees) external {
         onlyGovernance();
         uint256 minFeeRequired = MIN_POOL_CONTRIBUTION + FEE_AMOUNT;
@@ -350,7 +352,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
         uint256 totalRefundableAmount = channelData.poolContribution;
         // Update POOL_FUNDS & PROTOCOL_POOL_FEES
         CHANNEL_POOL_FUNDS = CHANNEL_POOL_FUNDS - totalRefundableAmount;
-        
+
         if (msg.sender != pushChannelAdmin) {
             IERC20(PUSH_TOKEN_ADDRESS).safeTransfer(msg.sender, totalRefundableAmount);
         } else {

--- a/test/BaseTest.t.sol
+++ b/test/BaseTest.t.sol
@@ -91,6 +91,7 @@ abstract contract BaseTest is Test, Constants, Events {
         // Set-up Core Address in Comm & Vice-Versa
         vm.startPrank(actor.admin);
         commProxy.setEPNSCoreAddress(address(coreProxy));
+        commProxy.setPushTokenAddress(address(pushToken));
         coreProxy.setEpnsCommunicatorAddress(address(commProxy));
         vm.stopPrank();
 

--- a/test/PushComm/unit_tests/CommAdminActions/CommAdminActions.t.sol
+++ b/test/PushComm/unit_tests/CommAdminActions/CommAdminActions.t.sol
@@ -1,0 +1,102 @@
+pragma solidity ^0.8.0;
+import {BasePushCommTest} from "../BasePushCommTest.t.sol";
+import {Errors} from "contracts/libraries/Errors.sol";
+
+contract CommAdminActions_Test is BasePushCommTest {
+    function setUp() public override {
+        BasePushCommTest.setUp();
+    }
+
+    function test_REVERTWhen_Non_adminTriesToChangeCoreAddress() external {
+        // it should REVERT
+        changePrank(actor.bob_channel_owner);
+        vm.expectRevert(Errors.CallerNotAdmin.selector);
+        commProxy.setEPNSCoreAddress(address(123));
+        assertEq(commProxy.EPNSCoreAddress(), address(coreProxy));
+    }
+
+    function test_WhenAdminTriesToChangeCoreAddress() external {
+        // it should update the core address
+        changePrank(actor.admin);
+        commProxy.setEPNSCoreAddress(address(123));
+        assertEq(commProxy.EPNSCoreAddress(), address(123));
+    }
+
+    function test_REVERTWhen_Non_adminTriesToChangeGovernanceAddress()
+        external
+    {
+        // it should REVERT
+        changePrank(actor.bob_channel_owner);
+        vm.expectRevert(Errors.CallerNotAdmin.selector);
+        commProxy.setGovernanceAddress(actor.governance);
+        assertEq(commProxy.governance(), actor.admin);
+    }
+
+    function test_WhenAdminChangesTheGovernanceAddress() external {
+        // it should update the governance address
+        changePrank(actor.admin);
+        commProxy.setGovernanceAddress(actor.governance);
+        assertEq(commProxy.governance(), actor.governance);
+    }
+
+    function test_REVERTWhen_Non_adminTransfersThePushChannelAdminControl()
+        external
+    {
+        // it should REVERT
+        changePrank(actor.bob_channel_owner);
+        vm.expectRevert(Errors.CallerNotAdmin.selector);
+        commProxy.transferPushChannelAdminControl(actor.bob_channel_owner);
+        assertEq(commProxy.pushChannelAdmin(), actor.admin);
+    }
+
+    function test_REVERTWhen_AdminTransfersTheAdminControlToAZeroAddress()
+        external
+    {
+        // it should REVERT
+        changePrank(actor.admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.InvalidArgument_WrongAddress.selector,
+                address(0)
+            )
+        );
+        commProxy.transferPushChannelAdminControl(address(0));
+        assertEq(commProxy.pushChannelAdmin(), actor.admin);
+    }
+
+    function test_REVERTWhen_AdminTransfersTheAdminControlToItself() external {
+        // it should REVERT
+        changePrank(actor.admin);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.InvalidArgument_WrongAddress.selector,
+                actor.admin
+            )
+        );
+        commProxy.transferPushChannelAdminControl(actor.admin);
+    }
+
+    function test_WhenAdminTransfersAdminControlToCorrectAddress() external {
+        // it should update the admin control
+        changePrank(actor.admin);
+
+        commProxy.transferPushChannelAdminControl(actor.bob_channel_owner);
+        assertEq(commProxy.pushChannelAdmin(), actor.bob_channel_owner);
+    }
+
+    function test_REVERTWhen_Non_adminTriesToSetThePushTokenAddress() external {
+        // it should REVERT
+        changePrank(actor.bob_channel_owner);
+        vm.expectRevert(Errors.CallerNotAdmin.selector);
+        commProxy.setPushTokenAddress(address(123));
+        assertEq(commProxy.PUSH_TOKEN_ADDRESS(), address(pushToken));
+    }
+
+    function test_WhenAdminSetsThePushTokenAddress() external {
+        // it should update the push token address
+
+        changePrank(actor.admin);
+        commProxy.setPushTokenAddress(address(123));
+        assertEq(commProxy.PUSH_TOKEN_ADDRESS(), address(123));
+    }
+}

--- a/test/PushComm/unit_tests/CommAdminActions/CommAdminActions.t.sol
+++ b/test/PushComm/unit_tests/CommAdminActions/CommAdminActions.t.sol
@@ -7,7 +7,7 @@ contract CommAdminActions_Test is BasePushCommTest {
         BasePushCommTest.setUp();
     }
 
-    function test_REVERTWhen_Non_adminTriesToChangeCoreAddress() external {
+    function test_REVERTWhen_Non_adminTriesToChange_CoreAddress() external {
         // it should REVERT
         changePrank(actor.bob_channel_owner);
         vm.expectRevert(Errors.CallerNotAdmin.selector);
@@ -15,14 +15,14 @@ contract CommAdminActions_Test is BasePushCommTest {
         assertEq(commProxy.EPNSCoreAddress(), address(coreProxy));
     }
 
-    function test_WhenAdminTriesToChangeCoreAddress() external {
+    function test_WhenAdminTriesToChange_CoreAddress() external {
         // it should update the core address
         changePrank(actor.admin);
         commProxy.setEPNSCoreAddress(address(123));
         assertEq(commProxy.EPNSCoreAddress(), address(123));
     }
 
-    function test_REVERTWhen_Non_adminTriesToChangeGovernanceAddress()
+    function test_REVERTWhen_Non_adminTriesTo_ChangeGovernanceAddress()
         external
     {
         // it should REVERT
@@ -32,14 +32,14 @@ contract CommAdminActions_Test is BasePushCommTest {
         assertEq(commProxy.governance(), actor.admin);
     }
 
-    function test_WhenAdminChangesTheGovernanceAddress() external {
+    function test_WhenAdminChanges_GovernanceAddress() external {
         // it should update the governance address
         changePrank(actor.admin);
         commProxy.setGovernanceAddress(actor.governance);
         assertEq(commProxy.governance(), actor.governance);
     }
 
-    function test_REVERTWhen_Non_adminTransfersThePushChannelAdminControl()
+    function test_RevertWhen_NonAdminTransfers_PushChannelAdminControl()
         external
     {
         // it should REVERT
@@ -49,7 +49,7 @@ contract CommAdminActions_Test is BasePushCommTest {
         assertEq(commProxy.pushChannelAdmin(), actor.admin);
     }
 
-    function test_REVERTWhen_AdminTransfersTheAdminControlToAZeroAddress()
+    function test_RevertWhen_AdminTransfers_AdminControl_ToZeroAddress()
         external
     {
         // it should REVERT
@@ -64,7 +64,7 @@ contract CommAdminActions_Test is BasePushCommTest {
         assertEq(commProxy.pushChannelAdmin(), actor.admin);
     }
 
-    function test_REVERTWhen_AdminTransfersTheAdminControlToItself() external {
+    function test_RevertWhen_AdminTransfers_AdminControl_ToItself() external {
         // it should REVERT
         changePrank(actor.admin);
         vm.expectRevert(
@@ -76,7 +76,7 @@ contract CommAdminActions_Test is BasePushCommTest {
         commProxy.transferPushChannelAdminControl(actor.admin);
     }
 
-    function test_WhenAdminTransfersAdminControlToCorrectAddress() external {
+    function test_WhenAdminTransfers_AdminControl_ToCorrectAddress() external {
         // it should update the admin control
         changePrank(actor.admin);
 
@@ -84,7 +84,7 @@ contract CommAdminActions_Test is BasePushCommTest {
         assertEq(commProxy.pushChannelAdmin(), actor.bob_channel_owner);
     }
 
-    function test_REVERTWhen_Non_adminTriesToSetThePushTokenAddress() external {
+    function test_RevertWhen_NonAdminTriesToSet_ThePushTokenAddress() external {
         // it should REVERT
         changePrank(actor.bob_channel_owner);
         vm.expectRevert(Errors.CallerNotAdmin.selector);
@@ -92,7 +92,7 @@ contract CommAdminActions_Test is BasePushCommTest {
         assertEq(commProxy.PUSH_TOKEN_ADDRESS(), address(pushToken));
     }
 
-    function test_WhenAdminSetsThePushTokenAddress() external {
+    function test_WhenAdminSets_ThePushTokenAddress() external {
         // it should update the push token address
 
         changePrank(actor.admin);

--- a/test/PushComm/unit_tests/CommAdminActions/CommAdminActions.t.sol
+++ b/test/PushComm/unit_tests/CommAdminActions/CommAdminActions.t.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.8.0;
-import {BasePushCommTest} from "../BasePushCommTest.t.sol";
-import {Errors} from "contracts/libraries/Errors.sol";
+
+import { BasePushCommTest } from "../BasePushCommTest.t.sol";
+import { Errors } from "contracts/libraries/Errors.sol";
 
 contract CommAdminActions_Test is BasePushCommTest {
     function setUp() public override {
@@ -22,9 +23,7 @@ contract CommAdminActions_Test is BasePushCommTest {
         assertEq(commProxy.EPNSCoreAddress(), address(123));
     }
 
-    function test_REVERTWhen_Non_adminTriesTo_ChangeGovernanceAddress()
-        external
-    {
+    function test_REVERTWhen_Non_adminTriesTo_ChangeGovernanceAddress() external {
         // it should REVERT
         changePrank(actor.bob_channel_owner);
         vm.expectRevert(Errors.CallerNotAdmin.selector);
@@ -39,9 +38,7 @@ contract CommAdminActions_Test is BasePushCommTest {
         assertEq(commProxy.governance(), actor.governance);
     }
 
-    function test_RevertWhen_NonAdminTransfers_PushChannelAdminControl()
-        external
-    {
+    function test_RevertWhen_NonAdminTransfers_PushChannelAdminControl() external {
         // it should REVERT
         changePrank(actor.bob_channel_owner);
         vm.expectRevert(Errors.CallerNotAdmin.selector);
@@ -49,17 +46,10 @@ contract CommAdminActions_Test is BasePushCommTest {
         assertEq(commProxy.pushChannelAdmin(), actor.admin);
     }
 
-    function test_RevertWhen_AdminTransfers_AdminControl_ToZeroAddress()
-        external
-    {
+    function test_RevertWhen_AdminTransfers_AdminControl_ToZeroAddress() external {
         // it should REVERT
         changePrank(actor.admin);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.InvalidArgument_WrongAddress.selector,
-                address(0)
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidArgument_WrongAddress.selector, address(0)));
         commProxy.transferPushChannelAdminControl(address(0));
         assertEq(commProxy.pushChannelAdmin(), actor.admin);
     }
@@ -67,12 +57,7 @@ contract CommAdminActions_Test is BasePushCommTest {
     function test_RevertWhen_AdminTransfers_AdminControl_ToItself() external {
         // it should REVERT
         changePrank(actor.admin);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.InvalidArgument_WrongAddress.selector,
-                actor.admin
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidArgument_WrongAddress.selector, actor.admin));
         commProxy.transferPushChannelAdminControl(actor.admin);
     }
 

--- a/test/PushComm/unit_tests/CommAdminActions/CommAdminActions.tree
+++ b/test/PushComm/unit_tests/CommAdminActions/CommAdminActions.tree
@@ -1,0 +1,21 @@
+.
+├── when non-admin tries to change core address
+│   └── it should REVERT
+├── when admin tries to change core address
+│   └── it should update the core address
+├── when non-admin tries to change governance address
+│   └── it should REVERT
+├── when admin changes the governance address
+│   └── it should update the governance address
+├── when non-admin transfers the pushChannelAdmin control
+│   └── it should REVERT
+├── when admin transfers the admin control to a zero address
+│   └── it should REVERT
+├── when admin transfers the admin control to itself
+│   └── it should REVERT
+├── when admin transfers admin control to correct address
+│   └── it should update the admin control
+├── when non-admin tries to set the push token address
+│   └── it should REVERT
+└── when admin sets the push Token address
+    └── it should update the push token address

--- a/test/PushCore/unit_tests/CoreAdminActions/CoreAdminActions.t.sol
+++ b/test/PushCore/unit_tests/CoreAdminActions/CoreAdminActions.t.sol
@@ -1,0 +1,194 @@
+pragma solidity ^0.8.0;
+import {BasePushCoreTest} from "../BasePushCoreTest.t.sol";
+import {Errors} from "contracts/libraries/Errors.sol";
+
+contract CoreAdminActions_Test is BasePushCoreTest {
+    function setUp() public virtual override {
+        BasePushCoreTest.setUp();
+    }
+
+    function test_WhenNon_adminTriesToSetTheCommunicatorAddress() external {
+        // it should REVERT
+        vm.expectRevert(Errors.CallerNotAdmin.selector);
+        changePrank(actor.bob_channel_owner);
+        coreProxy.setEpnsCommunicatorAddress(address(123));
+        assertTrue(coreProxy.epnsCommunicator() != address(123));
+    }
+
+    function test_WhenAdminTriesToSetTheCommunicatorAddress() external {
+        // it should succesfuly set the communicator address
+        changePrank(actor.admin);
+        coreProxy.setEpnsCommunicatorAddress(address(0x0));
+        assertTrue(coreProxy.epnsCommunicator() == address(0x0));
+    }
+
+    function test_REVERTWhen_Non_adminTriesToSetTheGovernanceAddress()
+        external
+    {
+        // it should REVERT
+        vm.expectRevert(Errors.CallerNotAdmin.selector);
+        changePrank(actor.bob_channel_owner);
+        coreProxy.setGovernanceAddress(actor.governance);
+        assertTrue(coreProxy.governance() != actor.governance);
+    }
+
+    function test_WhenAdminTriesToSetTheGovernanceAddress() external {
+        // it should succesfuly set the governance address
+        changePrank(actor.admin);
+        coreProxy.setGovernanceAddress(actor.governance);
+        assertTrue(coreProxy.governance() == actor.governance);
+    }
+
+    modifier whenAdminTransfersTheAdminControl() {
+        _;
+    }
+
+    function test_REVERTWhen_Non_adminTriesToTransferAdminControl()
+        external
+        whenAdminTransfersTheAdminControl
+    {
+        // it should REVERT
+        vm.expectRevert(Errors.CallerNotAdmin.selector);
+        changePrank(actor.bob_channel_owner);
+        coreProxy.transferPushChannelAdminControl(actor.bob_channel_owner);
+        assertTrue(coreProxy.pushChannelAdmin() == actor.admin);
+    }
+
+    function test_REVERTWhen_TheNewAdminAddressIsZeroAddress()
+        external
+        whenAdminTransfersTheAdminControl
+    {
+        // it should REVERT Errors.InvalidArgument_WrongAddress
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.InvalidArgument_WrongAddress.selector,
+                address(0)
+            )
+        );
+        changePrank(actor.admin);
+        coreProxy.transferPushChannelAdminControl(address(0));
+        assertTrue(coreProxy.pushChannelAdmin() == actor.admin);
+    }
+
+    function test_REVERTWhen_TheNewAdminAddressIsSameAsOldAdminAddress()
+        external
+        whenAdminTransfersTheAdminControl
+    {
+        // it should REVERT
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.InvalidArgument_WrongAddress.selector,
+                actor.admin
+            )
+        );
+        changePrank(actor.admin);
+        coreProxy.transferPushChannelAdminControl(actor.admin);
+    }
+
+    function test_WhenTheNewAdminAddressIsCorrect()
+        external
+        whenAdminTransfersTheAdminControl
+    {
+        // it should change the admin address
+        changePrank(actor.admin);
+        coreProxy.transferPushChannelAdminControl(actor.charlie_channel_owner);
+        assertTrue(coreProxy.pushChannelAdmin() == actor.charlie_channel_owner);
+    }
+
+    modifier whenTheGovernanceCallsTheSetterFunctions() {
+        changePrank(actor.admin);
+        coreProxy.setGovernanceAddress(actor.governance);
+        _;
+    }
+
+    function test_REVERTWhen_NewFeeIsGreaterThanOrEqualToAddChannelFees()
+        external
+        whenTheGovernanceCallsTheSetterFunctions
+    {
+        // it should REVERT
+        uint addChannelMin = coreProxy.ADD_CHANNEL_MIN_FEES();
+        vm.expectRevert();
+        changePrank(actor.governance);
+        coreProxy.setFeeAmount(addChannelMin);
+        vm.expectRevert();
+        coreProxy.setFeeAmount(addChannelMin + 1000);
+    }
+
+    function test_WhenNewFeeIsSmallerThanAddChannelFees()
+        external
+        whenTheGovernanceCallsTheSetterFunctions
+    {
+        // it should update the FEE_AMOUNT
+        uint addChannelMin = coreProxy.ADD_CHANNEL_MIN_FEES();
+        changePrank(actor.governance);
+        coreProxy.setFeeAmount(addChannelMin - 1);
+        assertEq(coreProxy.FEE_AMOUNT(), addChannelMin - 1);
+    }
+
+    //TODO - add a test for FEE_AMOUNT never being 0 after merging PR- 260
+
+    function test_RevertWhen_TheNewValueIsZero()
+        external
+        whenTheGovernanceCallsTheSetterFunctions
+    {
+        // it should revert Errors.InvalidArg_LessThanExpected(0, _newAmount);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.InvalidArg_LessThanExpected.selector,
+                0,
+                0
+            )
+        );
+        changePrank(actor.governance);
+        coreProxy.setMinPoolContribution(0);
+    }
+
+    function test_WhenTheNewValueIsGreaterThanZero()
+        external
+        whenTheGovernanceCallsTheSetterFunctions
+    {
+        // it should update the MinPoolContribution
+        changePrank(actor.governance);
+        coreProxy.setMinPoolContribution(1);
+        assertEq(coreProxy.MIN_POOL_CONTRIBUTION(), 1);
+    }
+
+    modifier whenGovernanceSetsTheMinChannelCreationFees() {
+        _;
+    }
+
+    function test_WhenNewFeesIsSmallerThanMinRequiredFees()
+        external
+        whenTheGovernanceCallsTheSetterFunctions
+        whenGovernanceSetsTheMinChannelCreationFees
+    {
+        uint256 minFeeRequired = coreProxy.MIN_POOL_CONTRIBUTION() +
+            coreProxy.FEE_AMOUNT();
+        // it should REVERT
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.InvalidArg_LessThanExpected.selector,
+                minFeeRequired,
+                minFeeRequired - 10
+            )
+        );
+        changePrank(actor.governance);
+        coreProxy.setMinChannelCreationFees(minFeeRequired - 10);
+    }
+
+    function test_WhenNewFeesIsGreaterOrEqualToMinRequiredFees()
+        external
+        whenTheGovernanceCallsTheSetterFunctions
+        whenGovernanceSetsTheMinChannelCreationFees
+    {
+        // it should update the minChannelCreationFees
+        uint256 minFeeRequired = coreProxy.MIN_POOL_CONTRIBUTION() +
+            coreProxy.FEE_AMOUNT();
+        // it should REVERT
+        changePrank(actor.governance);
+        coreProxy.setMinChannelCreationFees(minFeeRequired);
+        assertEq(coreProxy.ADD_CHANNEL_MIN_FEES(), minFeeRequired);
+        coreProxy.setMinChannelCreationFees(minFeeRequired + 10);
+        assertEq(coreProxy.ADD_CHANNEL_MIN_FEES(), minFeeRequired + 10);
+    }
+}

--- a/test/PushCore/unit_tests/CoreAdminActions/CoreAdminActions.t.sol
+++ b/test/PushCore/unit_tests/CoreAdminActions/CoreAdminActions.t.sol
@@ -7,32 +7,32 @@ contract CoreAdminActions_Test is BasePushCoreTest {
         BasePushCoreTest.setUp();
     }
 
-    function test_WhenNon_adminTriesToSetTheCommunicatorAddress() external {
-        // it should REVERT
+    function test_WhenNonAdminTriesTo_Set_CommunicatorAddress() external {
+        // it should Revert
         vm.expectRevert(Errors.CallerNotAdmin.selector);
         changePrank(actor.bob_channel_owner);
         coreProxy.setEpnsCommunicatorAddress(address(123));
         assertTrue(coreProxy.epnsCommunicator() != address(123));
     }
 
-    function test_WhenAdminTriesToSetTheCommunicatorAddress() external {
+    function test_WhenAdmin_TriesToSet_CommunicatorAddress() external {
         // it should succesfuly set the communicator address
         changePrank(actor.admin);
         coreProxy.setEpnsCommunicatorAddress(address(0x0));
         assertTrue(coreProxy.epnsCommunicator() == address(0x0));
     }
 
-    function test_REVERTWhen_Non_adminTriesToSetTheGovernanceAddress()
+    function test_RevertWhenNonAdmin_Set_GovernanceAddress()
         external
     {
-        // it should REVERT
+        // it should Revert
         vm.expectRevert(Errors.CallerNotAdmin.selector);
         changePrank(actor.bob_channel_owner);
         coreProxy.setGovernanceAddress(actor.governance);
         assertTrue(coreProxy.governance() != actor.governance);
     }
 
-    function test_WhenAdminTriesToSetTheGovernanceAddress() external {
+    function test_WhenAdmin_TriesToSet_GovernanceAddress() external {
         // it should succesfuly set the governance address
         changePrank(actor.admin);
         coreProxy.setGovernanceAddress(actor.governance);
@@ -43,22 +43,22 @@ contract CoreAdminActions_Test is BasePushCoreTest {
         _;
     }
 
-    function test_REVERTWhen_Non_adminTriesToTransferAdminControl()
+    function test_RevertWhen_NonAdminTriesTo_TransferAdminControl()
         external
         whenAdminTransfersTheAdminControl
     {
-        // it should REVERT
+        // it should Revert
         vm.expectRevert(Errors.CallerNotAdmin.selector);
         changePrank(actor.bob_channel_owner);
         coreProxy.transferPushChannelAdminControl(actor.bob_channel_owner);
         assertTrue(coreProxy.pushChannelAdmin() == actor.admin);
     }
 
-    function test_REVERTWhen_TheNewAdminAddressIsZeroAddress()
+    function test_RevertWhen_NewAdminAddress_IsZeroAddress()
         external
         whenAdminTransfersTheAdminControl
     {
-        // it should REVERT Errors.InvalidArgument_WrongAddress
+        // it should Revert Errors.InvalidArgument_WrongAddress
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.InvalidArgument_WrongAddress.selector,
@@ -70,11 +70,11 @@ contract CoreAdminActions_Test is BasePushCoreTest {
         assertTrue(coreProxy.pushChannelAdmin() == actor.admin);
     }
 
-    function test_REVERTWhen_TheNewAdminAddressIsSameAsOldAdminAddress()
+    function test_RevertWhen_NewAdminAddress_IsSameAs_OldAdminAddress()
         external
         whenAdminTransfersTheAdminControl
     {
-        // it should REVERT
+        // it should Revert
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.InvalidArgument_WrongAddress.selector,
@@ -85,7 +85,7 @@ contract CoreAdminActions_Test is BasePushCoreTest {
         coreProxy.transferPushChannelAdminControl(actor.admin);
     }
 
-    function test_WhenTheNewAdminAddressIsCorrect()
+    function test_WhenNewAdmin_AddressIsCorrect()
         external
         whenAdminTransfersTheAdminControl
     {
@@ -95,17 +95,17 @@ contract CoreAdminActions_Test is BasePushCoreTest {
         assertTrue(coreProxy.pushChannelAdmin() == actor.charlie_channel_owner);
     }
 
-    modifier whenTheGovernanceCallsTheSetterFunctions() {
+    modifier when_GovernanceCalls_TheSetterFunctions() {
         changePrank(actor.admin);
         coreProxy.setGovernanceAddress(actor.governance);
         _;
     }
 
-    function test_REVERTWhen_NewFeeIsGreaterThanOrEqualToAddChannelFees()
+    function test_RevertWhen_NewFeeIs_GreaterThanOrEqualTo_AddChannelFees()
         external
-        whenTheGovernanceCallsTheSetterFunctions
+        when_GovernanceCalls_TheSetterFunctions
     {
-        // it should REVERT
+        // it should Revert
         uint addChannelMin = coreProxy.ADD_CHANNEL_MIN_FEES();
         vm.expectRevert();
         changePrank(actor.governance);
@@ -114,9 +114,9 @@ contract CoreAdminActions_Test is BasePushCoreTest {
         coreProxy.setFeeAmount(addChannelMin + 1000);
     }
 
-    function test_WhenNewFeeIsSmallerThanAddChannelFees()
+    function test_WhenNewFee_IsSmaller_ThanAddChannelFees()
         external
-        whenTheGovernanceCallsTheSetterFunctions
+        when_GovernanceCalls_TheSetterFunctions
     {
         // it should update the FEE_AMOUNT
         uint addChannelMin = coreProxy.ADD_CHANNEL_MIN_FEES();
@@ -129,9 +129,9 @@ contract CoreAdminActions_Test is BasePushCoreTest {
 
     function test_RevertWhen_TheNewValueIsZero()
         external
-        whenTheGovernanceCallsTheSetterFunctions
+        when_GovernanceCalls_TheSetterFunctions
     {
-        // it should revert Errors.InvalidArg_LessThanExpected(0, _newAmount);
+        // it should Revert Errors.InvalidArg_LessThanExpected(0, _newAmount);
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.InvalidArg_LessThanExpected.selector,
@@ -143,9 +143,9 @@ contract CoreAdminActions_Test is BasePushCoreTest {
         coreProxy.setMinPoolContribution(0);
     }
 
-    function test_WhenTheNewValueIsGreaterThanZero()
+    function test_WhenTheNewValue_IsGreaterThanZero()
         external
-        whenTheGovernanceCallsTheSetterFunctions
+        when_GovernanceCalls_TheSetterFunctions
     {
         // it should update the MinPoolContribution
         changePrank(actor.governance);
@@ -157,14 +157,14 @@ contract CoreAdminActions_Test is BasePushCoreTest {
         _;
     }
 
-    function test_WhenNewFeesIsSmallerThanMinRequiredFees()
+    function test_WhenNewFees_IsSmallerThan_MinRequiredFees()
         external
-        whenTheGovernanceCallsTheSetterFunctions
+        when_GovernanceCalls_TheSetterFunctions
         whenGovernanceSetsTheMinChannelCreationFees
     {
         uint256 minFeeRequired = coreProxy.MIN_POOL_CONTRIBUTION() +
             coreProxy.FEE_AMOUNT();
-        // it should REVERT
+        // it should Revert
         vm.expectRevert(
             abi.encodeWithSelector(
                 Errors.InvalidArg_LessThanExpected.selector,
@@ -176,15 +176,15 @@ contract CoreAdminActions_Test is BasePushCoreTest {
         coreProxy.setMinChannelCreationFees(minFeeRequired - 10);
     }
 
-    function test_WhenNewFeesIsGreaterOrEqualToMinRequiredFees()
+    function test_WhenNewFees_IsGreaterOrEqualTo_MinRequiredFees()
         external
-        whenTheGovernanceCallsTheSetterFunctions
+        when_GovernanceCalls_TheSetterFunctions
         whenGovernanceSetsTheMinChannelCreationFees
     {
         // it should update the minChannelCreationFees
         uint256 minFeeRequired = coreProxy.MIN_POOL_CONTRIBUTION() +
             coreProxy.FEE_AMOUNT();
-        // it should REVERT
+        // it should Revert
         changePrank(actor.governance);
         coreProxy.setMinChannelCreationFees(minFeeRequired);
         assertEq(coreProxy.ADD_CHANNEL_MIN_FEES(), minFeeRequired);

--- a/test/PushCore/unit_tests/CoreAdminActions/CoreAdminActions.t.sol
+++ b/test/PushCore/unit_tests/CoreAdminActions/CoreAdminActions.t.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.8.0;
-import {BasePushCoreTest} from "../BasePushCoreTest.t.sol";
-import {Errors} from "contracts/libraries/Errors.sol";
+
+import { BasePushCoreTest } from "../BasePushCoreTest.t.sol";
+import { Errors } from "contracts/libraries/Errors.sol";
 
 contract CoreAdminActions_Test is BasePushCoreTest {
     function setUp() public virtual override {
@@ -22,9 +23,7 @@ contract CoreAdminActions_Test is BasePushCoreTest {
         assertTrue(coreProxy.epnsCommunicator() == address(0x0));
     }
 
-    function test_RevertWhenNonAdmin_Set_GovernanceAddress()
-        external
-    {
+    function test_RevertWhenNonAdmin_Set_GovernanceAddress() external {
         // it should Revert
         vm.expectRevert(Errors.CallerNotAdmin.selector);
         changePrank(actor.bob_channel_owner);
@@ -43,10 +42,7 @@ contract CoreAdminActions_Test is BasePushCoreTest {
         _;
     }
 
-    function test_RevertWhen_NonAdminTriesTo_TransferAdminControl()
-        external
-        whenAdminTransfersTheAdminControl
-    {
+    function test_RevertWhen_NonAdminTriesTo_TransferAdminControl() external whenAdminTransfersTheAdminControl {
         // it should Revert
         vm.expectRevert(Errors.CallerNotAdmin.selector);
         changePrank(actor.bob_channel_owner);
@@ -54,41 +50,22 @@ contract CoreAdminActions_Test is BasePushCoreTest {
         assertTrue(coreProxy.pushChannelAdmin() == actor.admin);
     }
 
-    function test_RevertWhen_NewAdminAddress_IsZeroAddress()
-        external
-        whenAdminTransfersTheAdminControl
-    {
+    function test_RevertWhen_NewAdminAddress_IsZeroAddress() external whenAdminTransfersTheAdminControl {
         // it should Revert Errors.InvalidArgument_WrongAddress
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.InvalidArgument_WrongAddress.selector,
-                address(0)
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidArgument_WrongAddress.selector, address(0)));
         changePrank(actor.admin);
         coreProxy.transferPushChannelAdminControl(address(0));
         assertTrue(coreProxy.pushChannelAdmin() == actor.admin);
     }
 
-    function test_RevertWhen_NewAdminAddress_IsSameAs_OldAdminAddress()
-        external
-        whenAdminTransfersTheAdminControl
-    {
+    function test_RevertWhen_NewAdminAddress_IsSameAs_OldAdminAddress() external whenAdminTransfersTheAdminControl {
         // it should Revert
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.InvalidArgument_WrongAddress.selector,
-                actor.admin
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidArgument_WrongAddress.selector, actor.admin));
         changePrank(actor.admin);
         coreProxy.transferPushChannelAdminControl(actor.admin);
     }
 
-    function test_WhenNewAdmin_AddressIsCorrect()
-        external
-        whenAdminTransfersTheAdminControl
-    {
+    function test_WhenNewAdmin_AddressIsCorrect() external whenAdminTransfersTheAdminControl {
         // it should change the admin address
         changePrank(actor.admin);
         coreProxy.transferPushChannelAdminControl(actor.charlie_channel_owner);
@@ -106,7 +83,7 @@ contract CoreAdminActions_Test is BasePushCoreTest {
         when_GovernanceCalls_TheSetterFunctions
     {
         // it should Revert
-        uint addChannelMin = coreProxy.ADD_CHANNEL_MIN_FEES();
+        uint256 addChannelMin = coreProxy.ADD_CHANNEL_MIN_FEES();
         vm.expectRevert();
         changePrank(actor.governance);
         coreProxy.setFeeAmount(addChannelMin);
@@ -114,12 +91,9 @@ contract CoreAdminActions_Test is BasePushCoreTest {
         coreProxy.setFeeAmount(addChannelMin + 1000);
     }
 
-    function test_WhenNewFee_IsSmaller_ThanAddChannelFees()
-        external
-        when_GovernanceCalls_TheSetterFunctions
-    {
+    function test_WhenNewFee_IsSmaller_ThanAddChannelFees() external when_GovernanceCalls_TheSetterFunctions {
         // it should update the FEE_AMOUNT
-        uint addChannelMin = coreProxy.ADD_CHANNEL_MIN_FEES();
+        uint256 addChannelMin = coreProxy.ADD_CHANNEL_MIN_FEES();
         changePrank(actor.governance);
         coreProxy.setFeeAmount(addChannelMin - 1);
         assertEq(coreProxy.FEE_AMOUNT(), addChannelMin - 1);
@@ -127,26 +101,14 @@ contract CoreAdminActions_Test is BasePushCoreTest {
 
     //TODO - add a test for FEE_AMOUNT never being 0 after merging PR- 260
 
-    function test_RevertWhen_TheNewValueIsZero()
-        external
-        when_GovernanceCalls_TheSetterFunctions
-    {
+    function test_RevertWhen_TheNewValueIsZero() external when_GovernanceCalls_TheSetterFunctions {
         // it should Revert Errors.InvalidArg_LessThanExpected(0, _newAmount);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.InvalidArg_LessThanExpected.selector,
-                0,
-                0
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidArg_LessThanExpected.selector, 0, 0));
         changePrank(actor.governance);
         coreProxy.setMinPoolContribution(0);
     }
 
-    function test_WhenTheNewValue_IsGreaterThanZero()
-        external
-        when_GovernanceCalls_TheSetterFunctions
-    {
+    function test_WhenTheNewValue_IsGreaterThanZero() external when_GovernanceCalls_TheSetterFunctions {
         // it should update the MinPoolContribution
         changePrank(actor.governance);
         coreProxy.setMinPoolContribution(1);
@@ -162,15 +124,10 @@ contract CoreAdminActions_Test is BasePushCoreTest {
         when_GovernanceCalls_TheSetterFunctions
         whenGovernanceSetsTheMinChannelCreationFees
     {
-        uint256 minFeeRequired = coreProxy.MIN_POOL_CONTRIBUTION() +
-            coreProxy.FEE_AMOUNT();
+        uint256 minFeeRequired = coreProxy.MIN_POOL_CONTRIBUTION() + coreProxy.FEE_AMOUNT();
         // it should Revert
         vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.InvalidArg_LessThanExpected.selector,
-                minFeeRequired,
-                minFeeRequired - 10
-            )
+            abi.encodeWithSelector(Errors.InvalidArg_LessThanExpected.selector, minFeeRequired, minFeeRequired - 10)
         );
         changePrank(actor.governance);
         coreProxy.setMinChannelCreationFees(minFeeRequired - 10);
@@ -182,8 +139,7 @@ contract CoreAdminActions_Test is BasePushCoreTest {
         whenGovernanceSetsTheMinChannelCreationFees
     {
         // it should update the minChannelCreationFees
-        uint256 minFeeRequired = coreProxy.MIN_POOL_CONTRIBUTION() +
-            coreProxy.FEE_AMOUNT();
+        uint256 minFeeRequired = coreProxy.MIN_POOL_CONTRIBUTION() + coreProxy.FEE_AMOUNT();
         // it should Revert
         changePrank(actor.governance);
         coreProxy.setMinChannelCreationFees(minFeeRequired);

--- a/test/PushCore/unit_tests/CoreAdminActions/CoreAdminActions.tree
+++ b/test/PushCore/unit_tests/CoreAdminActions/CoreAdminActions.tree
@@ -1,0 +1,34 @@
+.
+├── when non-admin tries to set the communicator address
+│   └── it should REVERT
+├── when admin tries to set the communicator address
+│   └── it should succesfuly set the communicator address
+├── when non-admin tries to set the governance address
+│   └── it should REVERT
+├── when admin tries to set the governance address
+│   └── it should succesfuly set the governance address
+├── when admin control is transferred
+│   ├── when non-admin tries to transfer admin control
+│   │   └── it should REVERT
+│   ├── when the new admin address is zero address
+│   │   └── it should REVERT
+│   ├── when the new admin address is same as old admin address
+│   │   └── it should REVERT
+│   └── when the new admin address is correct
+│       └── it should change the admin address
+├── when the governance calls the setter functions
+│   └── when governance tries to set the feeAmount
+│       ├── when new fee is greater than or equal to addChannelFees
+│       │   └── it should REVERT
+│       └── when new fee is smaller than addChannelFees
+│           └── it should update the FEE_AMOUNT
+├── when governance tries to set the MinPoolContribution
+│   ├── when the new value is zero
+│   │   └── it should revert
+│   └── when the new value is greater than zero
+│       └── it should update the MinPoolContribution
+└── when governance sets the minChannelCreationFees
+    ├── when new Fees is smaller than minRequiredFees
+    │   └── it should REVERT
+    └── when new fees is greater or equal to minRequiredFees
+        └── it should update the minChannelCreationFees


### PR DESCRIPTION
This PR contains the Tests for Admin-only setter functions, handling issue https://github.com/ethereum-push-notification-service/push-smart-contracts/issues/256

need a minor change after merging PR https://github.com/ethereum-push-notification-service/push-smart-contracts/pull/260