### PR TITLE
262 use block.chainid instead of yul

### DIFF
--- a/contracts/PushComm/PushCommV2_5.sol
+++ b/contracts/PushComm/PushCommV2_5.sol
@@ -57,7 +57,7 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2, IPushCommV2 {
         pushChannelAdmin = _pushChannelAdmin;
         governance = _pushChannelAdmin;
         chainName = _chainName;
-        chainID = BaseHelper.getChainId();
+        chainID = block.chainid;
         return true;
     }
 
@@ -218,7 +218,7 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2, IPushCommV2 {
         }
 
         bytes32 domainSeparator =
-            keccak256(abi.encode(DOMAIN_TYPEHASH, NAME_HASH, BaseHelper.getChainId(), address(this)));
+            keccak256(abi.encode(DOMAIN_TYPEHASH, NAME_HASH, block.chainid, address(this)));
         bytes32 structHash = keccak256(abi.encode(SUBSCRIBE_TYPEHASH, channel, subscriber, nonce, expiry));
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
 
@@ -321,7 +321,7 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2, IPushCommV2 {
 
         // EIP-712
         bytes32 domainSeparator =
-            keccak256(abi.encode(DOMAIN_TYPEHASH, NAME_HASH, BaseHelper.getChainId(), address(this)));
+            keccak256(abi.encode(DOMAIN_TYPEHASH, NAME_HASH, block.chainid, address(this)));
         bytes32 structHash = keccak256(abi.encode(UNSUBSCRIBE_TYPEHASH, channel, subscriber, nonce, expiry));
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
 
@@ -520,7 +520,7 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2, IPushCommV2 {
         }
 
         bytes32 domainSeparator =
-            keccak256(abi.encode(DOMAIN_TYPEHASH, NAME_HASH, BaseHelper.getChainId(), address(this)));
+            keccak256(abi.encode(DOMAIN_TYPEHASH, NAME_HASH, block.chainid, address(this)));
         bytes32 structHash =
             keccak256(abi.encode(SEND_NOTIFICATION_TYPEHASH, _channel, _recipient, keccak256(_identity), nonce, expiry));
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));

--- a/contracts/libraries/BaseHelper.sol
+++ b/contracts/libraries/BaseHelper.sol
@@ -4,14 +4,6 @@ pragma solidity ^0.8.20;
 /// @title CommHelper
 /// @notice Library with helper functions needed for the Push Communicator Contract
 library BaseHelper {
-    function getChainId() internal view returns (uint256) {
-        uint256 chainId;
-        assembly {
-            chainId := chainid()
-        }
-        return chainId;
-    }
-
     function isContract(address account) internal view returns (bool) {
         // This method relies on extcodesize, which returns 0 for contracts in
         // construction, since the code is only stored at the end of the

--- a/contracts/token/EPNS.sol
+++ b/contracts/token/EPNS.sol
@@ -152,7 +152,7 @@ contract EPNS {
         }
 
         bytes32 domainSeparator =
-            keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes(name)), BaseHelper.getChainId(), address(this)));
+            keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes(name)), block.chainid, address(this)));
         bytes32 structHash =
             keccak256(abi.encode(PERMIT_TYPEHASH, owner, spender, rawAmount, nonces[owner]++, deadline));
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
@@ -286,7 +286,7 @@ contract EPNS {
      */
     function delegateBySig(address delegatee, uint256 nonce, uint256 expiry, uint8 v, bytes32 r, bytes32 s) public {
         bytes32 domainSeparator =
-            keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes(name)), BaseHelper.getChainId(), address(this)));
+            keccak256(abi.encode(DOMAIN_TYPEHASH, keccak256(bytes(name)), block.chainid, address(this)));
         bytes32 structHash = keccak256(abi.encode(DELEGATION_TYPEHASH, delegatee, nonce, expiry));
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
         address signatory = ecrecover(digest, v, r, s);


### PR DESCRIPTION
Issue https://github.com/ethereum-push-notification-service/push-smart-contracts/issues/262

Removed the `getChainId` function from `baseHelper` and included `block.chainid` in `Comm` as well as `EPNS.sol`. 