### PR TITLE
286 include callernotgovernance as a global error

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
-[submodule "lib/forge-proposal-simulator"]
-	path = lib/forge-proposal-simulator
-	url = https://github.com/solidity-labs-io/forge-proposal-simulator

--- a/contracts/PushComm/PushCommV2_5.sol
+++ b/contracts/PushComm/PushCommV2_5.sol
@@ -43,6 +43,13 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2, IPushCommV2 {
         _;
     }
 
+    modifier onlyPushGovernance() {
+        if (msg.sender != governance) {
+            revert Errors.CallerNotGovernance();
+        }
+        _;
+    }
+    
     modifier onlyPushCore() {
         if (msg.sender != EPNSCoreAddress) {
             revert Errors.UnauthorizedCaller(msg.sender);

--- a/contracts/PushCore/PushCoreV2_5.sol
+++ b/contracts/PushCore/PushCoreV2_5.sol
@@ -80,7 +80,7 @@ contract PushCoreV2_5 is Initializable, PushCoreStorageV1_5, PausableUpgradeable
 
     function onlyGovernance() private view {
         if (msg.sender != governance) {
-            revert Errors.CallerNotAdmin();
+            revert Errors.CallerNotGovernance();
         }
     }
 

--- a/contracts/PushCore/PushCoreV2_Temp.sol
+++ b/contracts/PushCore/PushCoreV2_Temp.sol
@@ -81,7 +81,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
 
     function onlyGovernance() private view {
         if (msg.sender != governance) {
-            revert Errors.CallerNotAdmin();
+            revert Errors.CallerNotGovernance();
         }
     }
 

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -10,6 +10,8 @@ library Errors {
 
     /// @notice Reverts when `msg.sender` is not the admin of the contract.
     error CallerNotAdmin();
+    /// @notice Reverts when `msg.sender` is not the governance.
+    error CallerNotGovernance();
     /// @notice Reverts when `msg.sender` is not the admin of the contract.
     error UnauthorizedCaller(address caller);
     /// @notice Reverts when address argument is zero address or invalid for the function.

--- a/test/PushCore/unit_tests/ChannelStateCycle/blockChannel/blockChannel.t.sol
+++ b/test/PushCore/unit_tests/ChannelStateCycle/blockChannel/blockChannel.t.sol
@@ -18,8 +18,8 @@ contract BlockChannel_Test is BasePushCoreTest {
         _;
     }
 
-    function test_Revertwhen_BlockCallerNotAdmin() public whenNotPaused whenCallerIsAdmin {
-        vm.expectRevert(Errors.CallerNotAdmin.selector);
+    function test_Revertwhen_BlockCallerNotGovernance() public whenNotPaused whenCallerIsAdmin {
+        vm.expectRevert(Errors.CallerNotGovernance.selector);
 
         coreProxy.blockChannel(actor.bob_channel_owner);
     }

--- a/test/PushCore/unit_tests/ContractPausability/contractPausability.t.sol
+++ b/test/PushCore/unit_tests/ContractPausability/contractPausability.t.sol
@@ -12,27 +12,27 @@ contract ContractPausability_Test is BasePushCoreTest {
         _;
     }
 
-    function test_Revertwhen_PausingNotByGovernance() public whenNotPaused {
+    function test_Revertwhen_PausingNotByAdmin() public whenNotPaused {
         vm.prank(actor.bob_channel_owner);
         vm.expectRevert(abi.encodeWithSelector(Errors.CallerNotAdmin.selector));
         coreProxy.pauseContract();
     }
 
-    function test_Revertwhen_UnpausingNotByGovernance() public {
+    function test_Revertwhen_UnpausingNotByAdmin() public {
         vm.prank(actor.bob_channel_owner);
         vm.expectRevert(abi.encodeWithSelector(Errors.CallerNotAdmin.selector));
         coreProxy.unPauseContract();
     }
 
-    function test_PausingByGovernance() public whenNotPaused {
+    function test_PausingByAdmin() public whenNotPaused {
         vm.expectEmit(false, false, false, true, address(coreProxy));
         emit Paused(actor.admin);
 
-        vm.prank(actor.admin); // admin is governance until push migrates to on-chain governance
+        vm.prank(actor.admin);
         coreProxy.pauseContract();
     }
 
-    function test_UnpausingByGovernance() public {
+    function test_UnpausingByAdmin() public {
         vm.prank(actor.admin);
         coreProxy.pauseContract();
 


### PR DESCRIPTION
Solves https://github.com/ethereum-push-notification-service/push-smart-contracts/issues/285 and https://github.com/ethereum-push-notification-service/push-smart-contracts/issues/286