### PR TITLE
214 2nd new unwanted function removal

### DIFF
--- a/contracts/PushComm/PushCommV2_5.sol
+++ b/contracts/PushComm/PushCommV2_5.sol
@@ -412,8 +412,7 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2, IPushCommV2 {
      */
     function _checkNotifReq(address _channel, address _recipient) private view returns (bool) {
         if (
-            (_channel == 0x0000000000000000000000000000000000000000 && msg.sender == pushChannelAdmin)
-                || (_channel == msg.sender) || (delegatedNotificationSenders[_channel][msg.sender])
+            (_channel == msg.sender) || (delegatedNotificationSenders[_channel][msg.sender])
         ) {
             return true;
         }

--- a/contracts/PushComm/PushCommV2_5.sol
+++ b/contracts/PushComm/PushCommV2_5.sol
@@ -149,35 +149,35 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2, IPushCommV2 {
      * @param _usersList   array of addresses of the Users or Subscribers of the Channels
      *
      */
-    function migrateSubscribeData(
-        uint256 _startIndex,
-        uint256 _endIndex,
-        address[] calldata _channelList,
-        address[] calldata _usersList
-    )
-        external
-        onlyPushChannelAdmin
-        returns (bool)
-    {
-        if (isMigrationComplete || _channelList.length != _usersList.length) {
-            revert Errors.InvalidArg_ArrayLengthMismatch();
-        }
+    // function migrateSubscribeData(
+    //     uint256 _startIndex,
+    //     uint256 _endIndex,
+    //     address[] calldata _channelList,
+    //     address[] calldata _usersList
+    // )
+    //     external
+    //     onlyPushChannelAdmin
+    //     returns (bool)
+    // {
+    //     if (isMigrationComplete || _channelList.length != _usersList.length) {
+    //         revert Errors.InvalidArg_ArrayLengthMismatch();
+    //     }
 
-        for (uint256 i = _startIndex; i < _endIndex;) {
-            if (isUserSubscribed(_channelList[i], _usersList[i])) {
-                unchecked {
-                    i++;
-                }
-                continue;
-            } else {
-                _subscribe(_channelList[i], _usersList[i]);
-            }
-            unchecked {
-                i++;
-            }
-        }
-        return true;
-    }
+    //     for (uint256 i = _startIndex; i < _endIndex;) {
+    //         if (isUserSubscribed(_channelList[i], _usersList[i])) {
+    //             unchecked {
+    //                 i++;
+    //             }
+    //             continue;
+    //         } else {
+    //             _subscribe(_channelList[i], _usersList[i]);
+    //         }
+    //         unchecked {
+    //             i++;
+    //         }
+    //     }
+    //     return true;
+    // }
 
     /**
      * @notice Base Subscribe Function that allows users to Subscribe to a Particular Channel
@@ -358,12 +358,6 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2, IPushCommV2 {
         return true;
     }
 
-    /* **************
-
-    => PUBLIC KEY BROADCASTING & USER ADDING FUNCTIONALITIES <=
-
-    *************** */
-
     /**
      * @notice Activates/Adds a particular User's Address in the Protocol.
      *         Keeps track of the Total User Count
@@ -381,48 +375,6 @@ contract PushCommV2_5 is Initializable, PushCommStorageV2, IPushCommV2 {
 
             usersCount = usersCount + 1;
         }
-    }
-
-    /* @dev Internal system to handle broadcasting of public key,
-     *     A entry point for subscribe, or create channel but is optional
-     */
-    function _broadcastPublicKey(address _userAddr, bytes memory _publicKey) private {
-        // Add the user, will do nothing if added already, but is needed before broadcast
-        _addUser(_userAddr);
-
-        // get address from public key
-        address userAddr = getWalletFromPublicKey(_publicKey);
-
-        if (_userAddr == userAddr) {
-            // Only change it when verification suceeds, else assume the channel just wants to send group message
-            users[userAddr].publicKeyRegistered = true;
-
-            // Emit the event out
-            emit PublicKeyRegistered(userAddr, _publicKey);
-        } else {
-            revert("Public Key Validation Failed");
-        }
-    }
-
-    /// @dev Don't forget to add 0x into it
-    function getWalletFromPublicKey(bytes memory _publicKey) public pure returns (address wallet) {
-        if (_publicKey.length == 64) {
-            wallet = address(uint160(uint256(keccak256(_publicKey))));
-        } else {
-            wallet = 0x0000000000000000000000000000000000000000;
-        }
-    }
-
-    /// @dev Performs action by the user themself to broadcast their public key
-    function broadcastUserPublicKey(bytes calldata _publicKey) external {
-        // Will save gas
-        if (users[msg.sender].publicKeyRegistered) {
-            // Nothing to do, user already registered
-            return;
-        }
-
-        // broadcast it
-        _broadcastPublicKey(msg.sender, _publicKey);
     }
 
     /* *****************************

--- a/contracts/PushCore/PushCoreV2_5.sol
+++ b/contracts/PushCore/PushCoreV2_5.sol
@@ -318,10 +318,10 @@ contract PushCoreV2_5 is Initializable, PushCoreStorageV1_5, PausableUpgradeable
             PROTOCOL_POOL_FEES = PROTOCOL_POOL_FEES + totalRefundableAmount;
         }
         // Unsubscribing from imperative Channels
-        address _epnsCommunicator = epnsCommunicator;
-        IPushCommV2(_epnsCommunicator).unSubscribeViaCore(address(0x0), _channelAddress);
-        IPushCommV2(_epnsCommunicator).unSubscribeViaCore(_channelAddress, _channelAddress);
-        IPushCommV2(_epnsCommunicator).unSubscribeViaCore(_channelAddress, pushChannelAdmin);
+        // address _epnsCommunicator = epnsCommunicator;
+        // IPushCommV2(_epnsCommunicator).unSubscribeViaCore(address(0x0), _channelAddress);
+        // IPushCommV2(_epnsCommunicator).unSubscribeViaCore(_channelAddress, _channelAddress);
+        // IPushCommV2(_epnsCommunicator).unSubscribeViaCore(_channelAddress, pushChannelAdmin);
         // Decrement Channel Count and Delete Channel Completely
         channelsCount = channelsCount - 1;
         delete channels[_channelAddress];

--- a/contracts/PushCore/PushCoreV2_5.sol
+++ b/contracts/PushCore/PushCoreV2_5.sol
@@ -221,7 +221,7 @@ contract PushCoreV2_5 is Initializable, PushCoreStorageV1_5, PausableUpgradeable
             !(
                 _channelType == CoreTypes.ChannelType.InterestBearingOpen
                     || _channelType == CoreTypes.ChannelType.InterestBearingMutual
-                    || _channelType == CoreTypes.ChannelType.TimeBound || _channelType == CoreTypes.ChannelType.TokenGaited
+                    || _channelType == CoreTypes.ChannelType.TimeBound || _channelType == CoreTypes.ChannelType.TokenGated
             )
         ) {
             revert Errors.Core_InvalidChannelType();

--- a/contracts/PushCore/PushCoreV2_5.sol
+++ b/contracts/PushCore/PushCoreV2_5.sol
@@ -94,7 +94,6 @@ contract PushCoreV2_5 is Initializable, PushCoreStorageV1_5, PausableUpgradeable
         if (
             !(
                 (channels[_channel].channelState == 1 && msg.sender == _channel)
-                    || (msg.sender == pushChannelAdmin && _channel == address(0x0))
             )
         ) {
             revert Errors.UnauthorizedCaller(msg.sender);

--- a/contracts/PushCore/PushCoreV2_5.sol
+++ b/contracts/PushCore/PushCoreV2_5.sol
@@ -278,18 +278,6 @@ contract PushCoreV2_5 is Initializable, PushCoreStorageV1_5, PausableUpgradeable
             }
             channels[_channel].expiryTime = _channelExpiryTime;
         }
-
-        // Subscribe them to their own channel as well
-        address _epnsCommunicator = epnsCommunicator;
-        if (_channel != pushChannelAdmin) {
-            IPushCommV2(_epnsCommunicator).subscribeViaCore(_channel, _channel);
-        }
-
-        // All Channels are subscribed to EPNS Alerter as well, unless it's the EPNS Alerter channel iteself
-        if (_channel != address(0x0)) {
-            IPushCommV2(_epnsCommunicator).subscribeViaCore(address(0x0), _channel);
-            IPushCommV2(_epnsCommunicator).subscribeViaCore(_channel, pushChannelAdmin);
-        }
     }
 
     /// @inheritdoc IPushCoreV2

--- a/contracts/PushCore/PushCoreV2_5.sol
+++ b/contracts/PushCore/PushCoreV2_5.sol
@@ -434,7 +434,7 @@ contract PushCoreV2_5 is Initializable, PushCoreStorageV1_5, PausableUpgradeable
         bool logicComplete = false;
 
         // Check if it's primary verification
-        if (verifiedBy == pushChannelAdmin || _channel == address(0x0) || _channel == pushChannelAdmin) {
+        if (verifiedBy == pushChannelAdmin || _channel == pushChannelAdmin) {
             // primary verification, mark and exit
             verificationStatus = 1;
         } else {

--- a/contracts/PushCore/PushCoreV2_5.sol
+++ b/contracts/PushCore/PushCoreV2_5.sol
@@ -317,11 +317,6 @@ contract PushCoreV2_5 is Initializable, PushCoreStorageV1_5, PausableUpgradeable
         } else {
             PROTOCOL_POOL_FEES = PROTOCOL_POOL_FEES + totalRefundableAmount;
         }
-        // Unsubscribing from imperative Channels
-        // address _epnsCommunicator = epnsCommunicator;
-        // IPushCommV2(_epnsCommunicator).unSubscribeViaCore(address(0x0), _channelAddress);
-        // IPushCommV2(_epnsCommunicator).unSubscribeViaCore(_channelAddress, _channelAddress);
-        // IPushCommV2(_epnsCommunicator).unSubscribeViaCore(_channelAddress, pushChannelAdmin);
         // Decrement Channel Count and Delete Channel Completely
         channelsCount = channelsCount - 1;
         delete channels[_channelAddress];

--- a/contracts/PushCore/PushCoreV2_Temp.sol
+++ b/contracts/PushCore/PushCoreV2_Temp.sol
@@ -95,7 +95,6 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
         if (
             !(
                 (channels[_channel].channelState == 1 && msg.sender == _channel)
-                    || (msg.sender == pushChannelAdmin && _channel == address(0x0))
             )
         ) {
             revert Errors.UnauthorizedCaller(msg.sender);

--- a/contracts/PushCore/PushCoreV2_Temp.sol
+++ b/contracts/PushCore/PushCoreV2_Temp.sol
@@ -434,7 +434,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
         bool logicComplete = false;
 
         // Check if it's primary verification
-        if (verifiedBy == pushChannelAdmin || _channel == address(0x0) || _channel == pushChannelAdmin) {
+        if (verifiedBy == pushChannelAdmin || _channel == pushChannelAdmin) {
             // primary verification, mark and exit
             verificationStatus = 1;
         } else {

--- a/contracts/PushCore/PushCoreV2_Temp.sol
+++ b/contracts/PushCore/PushCoreV2_Temp.sol
@@ -317,11 +317,6 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
         } else {
             PROTOCOL_POOL_FEES = PROTOCOL_POOL_FEES + totalRefundableAmount;
         }
-        // Unsubscribing from imperative Channels
-        address _epnsCommunicator = epnsCommunicator;
-        IPushCommV2(_epnsCommunicator).unSubscribeViaCore(address(0x0), _channelAddress);
-        IPushCommV2(_epnsCommunicator).unSubscribeViaCore(_channelAddress, _channelAddress);
-        IPushCommV2(_epnsCommunicator).unSubscribeViaCore(_channelAddress, pushChannelAdmin);
         // Decrement Channel Count and Delete Channel Completely
         channelsCount = channelsCount - 1;
         delete channels[_channelAddress];

--- a/contracts/PushCore/PushCoreV2_Temp.sol
+++ b/contracts/PushCore/PushCoreV2_Temp.sol
@@ -278,18 +278,6 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
             }
             channels[_channel].expiryTime = _channelExpiryTime;
         }
-
-        // Subscribe them to their own channel as well
-        address _epnsCommunicator = epnsCommunicator;
-        if (_channel != pushChannelAdmin) {
-            IPushCommV2(_epnsCommunicator).subscribeViaCore(_channel, _channel);
-        }
-
-        // All Channels are subscribed to EPNS Alerter as well, unless it's the EPNS Alerter channel iteself
-        if (_channel != address(0x0)) {
-            IPushCommV2(_epnsCommunicator).subscribeViaCore(address(0x0), _channel);
-            IPushCommV2(_epnsCommunicator).subscribeViaCore(_channel, pushChannelAdmin);
-        }
     }
 
     /// @inheritdoc IPushCoreV2

--- a/contracts/PushCore/PushCoreV2_Temp.sol
+++ b/contracts/PushCore/PushCoreV2_Temp.sol
@@ -221,7 +221,7 @@ contract PushCoreV2_Temp is Initializable, PushCoreStorageV1_5, PausableUpgradea
             !(
                 _channelType == CoreTypes.ChannelType.InterestBearingOpen
                     || _channelType == CoreTypes.ChannelType.InterestBearingMutual
-                    || _channelType == CoreTypes.ChannelType.TimeBound || _channelType == CoreTypes.ChannelType.TokenGaited
+                    || _channelType == CoreTypes.ChannelType.TimeBound || _channelType == CoreTypes.ChannelType.TokenGated
             )
         ) {
             revert Errors.Core_InvalidChannelType();

--- a/contracts/libraries/DataTypes.sol
+++ b/contracts/libraries/DataTypes.sol
@@ -14,7 +14,7 @@ library CoreTypes {
         InterestBearingOpen,
         InterestBearingMutual,
         TimeBound,
-        TokenGaited
+        TokenGated
     }
 
     enum ChannelAction {

--- a/test/PushComm/unit_tests/SendingNotifications/SendNotifs.t.sol
+++ b/test/PushComm/unit_tests/SendingNotifications/SendNotifs.t.sol
@@ -20,11 +20,12 @@ contract SendNotifs_Test is BasePushCommTest {
         assertEq(res, false);
     }
 
-    function test_WhenChannelIs0x00_AndCallerIs_Admin() external {
-        changePrank(actor.admin);
-        bool res = commProxy.sendNotification(address(0), actor.alice_channel_owner, _testChannelIdentity);
-        assertEq(res, true);
-    }
+    // Alerter Support removed
+    // function test_WhenChannelIs0x00_AndCallerIs_Admin() external {
+    //     changePrank(actor.admin);
+    //     bool res = commProxy.sendNotification(address(0), actor.alice_channel_owner, _testChannelIdentity);
+    //     assertEq(res, true);
+    // }
 
     function test_WhenDelegate_SendNotification_WithoutApproval() external {
         bool isTonyDelegate = commProxy.delegatedNotificationSenders(actor.bob_channel_owner, actor.dan_push_holder);

--- a/test/PushCore/unit_tests/ChannelCreationPush/createChannelWithPUSH.t.sol
+++ b/test/PushCore/unit_tests/ChannelCreationPush/createChannelWithPUSH.t.sol
@@ -145,34 +145,6 @@ contract CreateChannelWithPUSH_Test is BasePushCoreTest {
         vm.stopPrank();
     }
 
-    function test_CoreInteractWithComm() public whenNotPaused {
-        vm.startPrank(actor.bob_channel_owner);
-        address EPNS_ALERTER = address(0);
-
-        bool isChannelSubscribedToOwn_Before =
-            commProxy.isUserSubscribed(actor.bob_channel_owner, actor.bob_channel_owner);
-        bool isChannelSubscribedToEPNS_Before = commProxy.isUserSubscribed(EPNS_ALERTER, actor.bob_channel_owner);
-        bool isAdminSubscribedToChannel_Before = commProxy.isUserSubscribed(actor.bob_channel_owner, actor.admin);
-
-        coreProxy.createChannelWithPUSH(
-            CoreTypes.ChannelType.InterestBearingOpen, _testChannelIdentity, ADD_CHANNEL_MIN_FEES, 0
-        );
-
-        bool isChannelSubscribedToOwn_After =
-            commProxy.isUserSubscribed(actor.bob_channel_owner, actor.bob_channel_owner);
-        bool isChannelSubscribedToEPNS_After = commProxy.isUserSubscribed(EPNS_ALERTER, actor.bob_channel_owner);
-        bool isAdminSubscribedToChannel_After = commProxy.isUserSubscribed(actor.bob_channel_owner, actor.admin);
-
-        assertEq(isChannelSubscribedToOwn_Before, false);
-        assertEq(isChannelSubscribedToEPNS_Before, false);
-        assertEq(isAdminSubscribedToChannel_Before, false);
-
-        assertEq(isChannelSubscribedToOwn_After, true);
-        assertEq(isChannelSubscribedToEPNS_After, true);
-        assertEq(isAdminSubscribedToChannel_After, true);
-
-        vm.stopPrank();
-    }
 
     function test_EmitRelevantEvents() public whenNotPaused {
         vm.expectEmit(true, true, false, true, address(coreProxy));
@@ -183,4 +155,35 @@ contract CreateChannelWithPUSH_Test is BasePushCoreTest {
             CoreTypes.ChannelType.InterestBearingOpen, _testChannelIdentity, ADD_CHANNEL_MIN_FEES, 0
         );
     }
+
+    // Auto-Subscription to Channels - Now Deprecated 
+
+    // function test_CoreInteractWithComm() public whenNotPaused {
+    //     vm.startPrank(actor.bob_channel_owner);
+    //     address EPNS_ALERTER = address(0);
+
+    //     bool isChannelSubscribedToOwn_Before =
+    //         commProxy.isUserSubscribed(actor.bob_channel_owner, actor.bob_channel_owner);
+    //     bool isChannelSubscribedToEPNS_Before = commProxy.isUserSubscribed(EPNS_ALERTER, actor.bob_channel_owner);
+    //     bool isAdminSubscribedToChannel_Before = commProxy.isUserSubscribed(actor.bob_channel_owner, actor.admin);
+
+    //     coreProxy.createChannelWithPUSH(
+    //         CoreTypes.ChannelType.InterestBearingOpen, _testChannelIdentity, ADD_CHANNEL_MIN_FEES, 0
+    //     );
+
+    //     bool isChannelSubscribedToOwn_After =
+    //         commProxy.isUserSubscribed(actor.bob_channel_owner, actor.bob_channel_owner);
+    //     bool isChannelSubscribedToEPNS_After = commProxy.isUserSubscribed(EPNS_ALERTER, actor.bob_channel_owner);
+    //     bool isAdminSubscribedToChannel_After = commProxy.isUserSubscribed(actor.bob_channel_owner, actor.admin);
+
+    //     assertEq(isChannelSubscribedToOwn_Before, false);
+    //     assertEq(isChannelSubscribedToEPNS_Before, false);
+    //     assertEq(isAdminSubscribedToChannel_Before, false);
+
+    //     assertEq(isChannelSubscribedToOwn_After, true);
+    //     assertEq(isChannelSubscribedToEPNS_After, true);
+    //     assertEq(isAdminSubscribedToChannel_After, true);
+
+    //     vm.stopPrank();
+    // }
 }

--- a/test/PushCore/unit_tests/ChannelUpdation/updateChannelMeta.t.sol
+++ b/test/PushCore/unit_tests/ChannelUpdation/updateChannelMeta.t.sol
@@ -49,14 +49,6 @@ contract UpdateChannelMeta_Test is BasePushCoreTest {
         coreProxy.updateChannelMeta(_channelAddress, _testChannelUpdatedIdentity, _amountBeingTransferred);
     }
 
-    function test_UpdateZeroAddressChannel() public whenNotPaused {
-        uint256 _amountBeingTransferred = ADD_CHANNEL_MIN_FEES;
-        address _channelAddress = address(0x0);
-
-        vm.prank(actor.admin);
-        coreProxy.updateChannelMeta(_channelAddress, _testChannelUpdatedIdentity, _amountBeingTransferred);
-    }
-
     function test_Revertwhen_AmountLessThanRequiredFees() public whenNotPaused {
         uint256 _amountBeingTransferred = ADD_CHANNEL_MIN_FEES - 10 ether;
         _createChannel(actor.bob_channel_owner);
@@ -168,4 +160,13 @@ contract UpdateChannelMeta_Test is BasePushCoreTest {
         vm.prank(actor.bob_channel_owner);
         coreProxy.updateChannelMeta(actor.bob_channel_owner, _testChannelUpdatedIdentity, _amountBeingTransferred);
     }
+
+    // Zero-Address Channel Support - Now Deprecated
+    // function test_UpdateZeroAddressChannel() public whenNotPaused {
+    //     uint256 _amountBeingTransferred = ADD_CHANNEL_MIN_FEES;
+    //     address _channelAddress = address(0x0);
+
+    //     vm.prank(actor.admin);
+    //     coreProxy.updateChannelMeta(_channelAddress, _testChannelUpdatedIdentity, _amountBeingTransferred);
+    // }
 }

--- a/test/PushCore/unit_tests/ChannelVerifyTag/ChannelVerification/ChannelVerification.t.sol
+++ b/test/PushCore/unit_tests/ChannelVerifyTag/ChannelVerification/ChannelVerification.t.sol
@@ -23,13 +23,10 @@ contract ChannelVerification_Test is BasePushCoreTest {
         uint8 zeroAddressVerification = coreProxy.getChannelVerfication(address(0));
 
         assertEq(adminVerification, 1);
-        assertEq(adminVerification, zeroAddressVerification);
 
         address Admin_verifiedBy = _getVerifiedBy(actor.admin);
-        address Zero_verifiedBy = _getVerifiedBy(address(0));
 
         assertEq(Admin_verifiedBy, address(0));
-        assertEq(Zero_verifiedBy, address(0));
     }
 
     function test_WhenChecked_TheVerificationStatusFor_UnverifiedChannel()

--- a/test/PushCore/unit_tests/TimeBoundChannel/timeBoundChannel.t.sol
+++ b/test/PushCore/unit_tests/TimeBoundChannel/timeBoundChannel.t.sol
@@ -247,34 +247,6 @@ contract TimeBoundChannel_Test is BasePushCoreTest {
         assertEq(expectedPushTokenBalanceOfAdminAfterDestroying, actualPushTokenBalanceOfAdminAfterDestroying);
     }
 
-    function test_ShouldUnsubscribeAfterDestroyed() public whenNotPaused {
-        _createTimeBoundChannel(actor.bob_channel_owner, _getFutureTime(1 days));
-        address EPNS_ALERTER = address(0);
-
-        bool isChannelSubscribedToOwn_Before =
-            commProxy.isUserSubscribed(actor.bob_channel_owner, actor.bob_channel_owner);
-        bool isChannelSubscribedToEPNS_Before = commProxy.isUserSubscribed(EPNS_ALERTER, actor.bob_channel_owner);
-        bool isAdminSubscribedToChannel_Before = commProxy.isUserSubscribed(actor.bob_channel_owner, actor.admin);
-
-        skip(1 days + 1 seconds);
-
-        vm.prank(actor.bob_channel_owner);
-        coreProxy.destroyTimeBoundChannel(actor.bob_channel_owner);
-
-        bool isChannelSubscribedToOwn_After =
-            commProxy.isUserSubscribed(actor.bob_channel_owner, actor.bob_channel_owner);
-        bool isChannelSubscribedToEPNS_After = commProxy.isUserSubscribed(EPNS_ALERTER, actor.bob_channel_owner);
-        bool isAdminSubscribedToChannel_After = commProxy.isUserSubscribed(actor.bob_channel_owner, actor.admin);
-
-        assertEq(isChannelSubscribedToOwn_Before, true);
-        assertEq(isChannelSubscribedToEPNS_Before, true);
-        assertEq(isAdminSubscribedToChannel_Before, true);
-
-        assertEq(isChannelSubscribedToOwn_After, false);
-        assertEq(isChannelSubscribedToEPNS_After, false);
-        assertEq(isAdminSubscribedToChannel_After, false);
-    }
-
     function test_ShouldDeleteDataAfterDestroyed() public whenNotPaused {
         _createTimeBoundChannel(actor.bob_channel_owner, _getFutureTime(1 days));
 
@@ -348,4 +320,34 @@ contract TimeBoundChannel_Test is BasePushCoreTest {
         vm.prank(actor.bob_channel_owner);
         coreProxy.destroyTimeBoundChannel(actor.bob_channel_owner);
     }
+
+    // Auto-Subscription Funcationality Removed
+    
+    // function test_ShouldUnsubscribeAfterDestroyed() public whenNotPaused {
+    //     _createTimeBoundChannel(actor.bob_channel_owner, _getFutureTime(1 days));
+    //     address EPNS_ALERTER = address(0);
+
+    //     bool isChannelSubscribedToOwn_Before =
+    //         commProxy.isUserSubscribed(actor.bob_channel_owner, actor.bob_channel_owner);
+    //     bool isChannelSubscribedToEPNS_Before = commProxy.isUserSubscribed(EPNS_ALERTER, actor.bob_channel_owner);
+    //     bool isAdminSubscribedToChannel_Before = commProxy.isUserSubscribed(actor.bob_channel_owner, actor.admin);
+
+    //     skip(1 days + 1 seconds);
+
+    //     vm.prank(actor.bob_channel_owner);
+    //     coreProxy.destroyTimeBoundChannel(actor.bob_channel_owner);
+
+    //     bool isChannelSubscribedToOwn_After =
+    //         commProxy.isUserSubscribed(actor.bob_channel_owner, actor.bob_channel_owner);
+    //     bool isChannelSubscribedToEPNS_After = commProxy.isUserSubscribed(EPNS_ALERTER, actor.bob_channel_owner);
+    //     bool isAdminSubscribedToChannel_After = commProxy.isUserSubscribed(actor.bob_channel_owner, actor.admin);
+
+    //     assertEq(isChannelSubscribedToOwn_Before, true);
+    //     assertEq(isChannelSubscribedToEPNS_Before, true);
+    //     assertEq(isAdminSubscribedToChannel_Before, true);
+
+    //     assertEq(isChannelSubscribedToOwn_After, false);
+    //     assertEq(isChannelSubscribedToEPNS_After, false);
+    //     assertEq(isAdminSubscribedToChannel_After, false);
+    // }
 }

--- a/test/PushCore/unit_tests/TimeBoundChannel/timeBoundChannel.t.sol
+++ b/test/PushCore/unit_tests/TimeBoundChannel/timeBoundChannel.t.sol
@@ -321,7 +321,7 @@ contract TimeBoundChannel_Test is BasePushCoreTest {
         coreProxy.destroyTimeBoundChannel(actor.bob_channel_owner);
     }
 
-    // Auto-Subscription Funcationality Removed
+    // Auto-UnSubscription from Channels - Now Deprecated
     
     // function test_ShouldUnsubscribeAfterDestroyed() public whenNotPaused {
     //     _createTimeBoundChannel(actor.bob_channel_owner, _getFutureTime(1 days));


### PR DESCRIPTION
This PR mainly includes 3 important changes:
- Removal of unwanted function from Comm Contract
- Removal of unwanted function from Core Contract
- Deprecate the support of EPNS Alerter (Zero-Address) channel


**List of changes if EPNS Alerter support is removed**
    1. **Modifiers**
        1. onlyChannelOwner
    2. **Functions**
        1. _createChannel → Line 289 :: Remove auto-supscription completely ✅
        2. destroyTimeBoundChannel → Line 322 :: Remove auto-unsubscription completely ✅
        3. getChannelVerfication → Line 437 :: remove address (0x0) ✅
        
    
    **Comm Function:**
    
    1. _checkNotifReq() → Line 415 :: Remove notification requirement support for alerter ✅


This PR resolves #214 and #282 